### PR TITLE
Bug fixes

### DIFF
--- a/ui/src/app/collection/create-collection/collection-form.component.ts
+++ b/ui/src/app/collection/create-collection/collection-form.component.ts
@@ -52,9 +52,7 @@ export class CollectionFormComponent extends Whitelabelled implements OnInit, Ha
       this.collectionLoaded.subscribe(collection => { this.setCollection(collection) })
     }
 
-    if (this.isAuthorEditable()) {
-      this.collectionForm.controls.author.setValue(AppConfig.settings.defaultAuthorValue)
-    }
+    this.collectionForm.controls.author.setValue(AppConfig.settings.defaultAuthorValue)
 
     this.titleService.setTitle(`${this.pageTitle()} | ${this.whitelabel.toolName}`)
   }
@@ -66,10 +64,7 @@ export class CollectionFormComponent extends Whitelabelled implements OnInit, Ha
   getFormDefinitions(): {[key: string]: AbstractControl} {
     const fields = {
       collectionName: new FormControl("", Validators.required),
-    }
-    if (this.isAuthorEditable()) {
-      // @ts-ignore
-      fields.author = new FormControl(AppConfig.settings.defaultAuthorValue, Validators.required)
+      author: new FormControl(AppConfig.settings.defaultAuthorValue, Validators.required)
     }
     return fields
   }
@@ -91,11 +86,8 @@ export class CollectionFormComponent extends Whitelabelled implements OnInit, Ha
   setCollection(collection: ApiCollection): void {
     this.existingCollection = collection
     const fields = {
-      collectionName: collection.name
-    }
-    if (AppConfig.settings.editableAuthor) {
-      // @ts-ignore
-      fields.author = this.stringFromNamedReference(collection.author)
+      collectionName: collection.name,
+      author: this.stringFromNamedReference(collection.author)
     }
     this.collectionForm.setValue(fields)
   }

--- a/ui/src/app/collection/service/collection.service.ts
+++ b/ui/src/app/collection/service/collection.service.ts
@@ -93,7 +93,7 @@ export class CollectionService extends AbstractService {
   // tslint:disable-next-line:no-any
   getCsvTaskResultsIfComplete(uuid: string): Observable<any> {
     return this.httpClient
-      .get(`api/results/text/${uuid}`, {
+      .get(this.buildUrl(`/api/results/text/${uuid}`), {
         responseType: "text",
         observe: "response"
       })

--- a/ui/src/app/richskill/form/rich-skill-form.component.ts
+++ b/ui/src/app/richskill/form/rich-skill-form.component.ts
@@ -116,10 +116,7 @@ export class RichSkillFormComponent extends Whitelabelled implements OnInit, Has
       certifications: new FormControl(""),
       occupations: new FormControl(""),
       employers: new FormControl(""),
-    }
-    if (AppConfig.settings.editableAuthor) {
-      // @ts-ignore
-      fields.author = new FormControl(AppConfig.settings.defaultAuthorValue, Validators.required)
+      author: new FormControl(AppConfig.settings.defaultAuthorValue, Validators.required)
     }
     return fields
   }
@@ -186,11 +183,9 @@ export class RichSkillFormComponent extends Whitelabelled implements OnInit, Has
       update.skillStatement = inputStatement
     }
 
-    if (AppConfig.settings.editableAuthor) {
-      const author = ApiNamedReference.fromString(formValue.author)
-      if (!this.existingSkill || this.isDuplicating || this.stringFromNamedReference(this.existingSkill.author) !== formValue.author) {
-        update.author = author
-      }
+    const author = ApiNamedReference.fromString(formValue.author)
+    if (!this.existingSkill || this.isDuplicating || this.stringFromNamedReference(this.existingSkill.author) !== formValue.author) {
+      update.author = author
     }
 
     const inputCategory = this.nonEmptyOrNull(formValue.category)
@@ -325,11 +320,8 @@ export class RichSkillFormComponent extends Whitelabelled implements OnInit, Has
       collections: skill.collections?.map(it => it.name) ?? [],
       certifications: skill.certifications?.map(it => this.stringFromNamedReference(it)).join("; ") ?? "",
       occupations: skill.occupations?.map(it => this.stringFromJobCode(it)).join("; ") ?? "",
-      employers: skill.employers?.map(it => this.stringFromNamedReference(it)).join("; ") ?? ""
-    }
-    if (AppConfig.settings.editableAuthor) {
-      // @ts-ignore
-      fields.author = this.stringFromNamedReference(skill.author)
+      employers: skill.employers?.map(it => this.stringFromNamedReference(it)).join("; ") ?? "",
+      author: this.stringFromNamedReference(skill.author)
     }
     this.skillForm.setValue(fields)
 

--- a/ui/src/app/richskill/list/skills-list.component.ts
+++ b/ui/src/app/richskill/list/skills-list.component.ts
@@ -19,6 +19,11 @@ import {TableActionBarComponent} from "../../table/skills-library-table/table-ac
   templateUrl: "./skills-list.component.html"
 })
 export class SkillsListComponent extends QuickLinksHelper {
+  /*
+   * In default configuration, ElasticSearch has an upper limit of returning 10000 elements.  For a short-term
+   * usability fix, we're simply going to add a "+" character when displaying 10000 (or more) total hits.
+   */
+  readonly upperLimit = 10000
 
   from = 0
   size = 50
@@ -64,7 +69,7 @@ export class SkillsListComponent extends QuickLinksHelper {
 
   get skillCountLabel(): string {
     if (this.totalCount > 0)  {
-      return `${this.totalCount} RSD${this.totalCount > 1 ? "s" : ""}`
+      return `${this.totalCount}${this.totalCount >= this.upperLimit ? "+" : ""} RSD${this.totalCount > 1 ? "s" : ""}`
     }
     return `0 RSDs`
   }

--- a/ui/src/app/search/advanced-search/advanced-search.component.ts
+++ b/ui/src/app/search/advanced-search/advanced-search.component.ts
@@ -41,11 +41,7 @@ export class AdvancedSearchComponent extends Whitelabelled implements OnInit {
       occupations: new FormControl(""),
       employers: new FormControl(""),
       alignments: new FormControl("", urlValidator),
-      collectionName: new FormControl("")
-    }
-    if (AppConfig.settings.editableAuthor) {
-      // @ts-ignore
-      fields.author = new FormControl(AppConfig.settings.defaultAuthorValue, Validators.required)
+      collectionName: new FormControl(""),
     }
     return fields
   }


### PR DESCRIPTION
* Removed isAuthorEditable() in many cases because the intent was separate from using the defaultAuthorValue, but was not coded separately.  i.e., if there is a defaultAuthorValue, then use it as the default.
* Fixed the assumption that the same web server is used for both UI and Service.  That's not always the case.
* Temporary handling of the ElasticSearch limitation of 10000 RSDs.  Until that is fixed by other means, we add a "+" to reduce confusion about the 10000 RSD count.