### PR TITLE
Limit log4j behavior in Spring properties

### DIFF
--- a/api/src/main/resources/config/application.properties
+++ b/api/src/main/resources/config/application.properties
@@ -74,3 +74,6 @@ app.baseLineAuditLogIfEmpty=true
 
 app.allowPublicSearching=true
 app.allowPublicLists=true
+
+# Limit log4j behaviors as partial stopgap for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+log4j2.formatMsgNoLookups=true


### PR DESCRIPTION
See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

This patch limits log4j behaviors in older versions of log4j. This is
added in OSMT as a just-in-case measure to limit the attack surface
for CVE-2021-4428