### PR TITLE
Update log4j dependency to 2.17.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -60,6 +60,10 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -108,6 +112,18 @@
             <artifactId>log4j-api</artifactId>
             <version>2.17.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.17.0</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-api</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.exposed</groupId>


### PR DESCRIPTION
See https://unit42.paloaltonetworks.com/apache-log4j-vulnerability-cve-2021-44228/