### PR TITLE
Fix error in API README

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -132,7 +132,7 @@ java -Dspring.profiles.active=<environment profile>,reindex -jar api/target/osmt
 
 Via mvn:
 ```
-mvn -DSpring.profiles.active=<environment profile>,reindex
+mvn -DSpring.profiles.active=<environment profile>,reindex spring-boot:run
 ```
 
 ### Reindex after changes to Elasticsearch `@Document` index classes


### PR DESCRIPTION
Part of the Maven command was missing in this section of the API README