### PR TITLE
Package OSMT endpoints as a library for other Spring apps

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -340,6 +340,7 @@
                                 <exclude>**/edu/wgu/osmt/ImportCommandRunner</exclude>
                                 <exclude>**/edu/wgu/osmt/security/SecurityConfig**</exclude>
                                 <exclude>**src/main/resources/ui/**</exclude>
+                                <exclude>**src/main/resources/config/application-oauth2-okta.properties</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -334,11 +334,12 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <classifier>app-to-import</classifier>
+                            <classifier>lib</classifier>
                             <excludes>
                                 <exclude>**/edu/wgu/osmt/Application</exclude>
                                 <exclude>**/edu/wgu/osmt/ImportCommandRunner</exclude>
                                 <exclude>**/edu/wgu/osmt/security/SecurityConfig**</exclude>
+                                <exclude>**src/main/resources/ui/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -323,6 +323,28 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>build-api-jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <classifier>app-to-import</classifier>
+                            <excludes>
+                                <exclude>**/edu/wgu/osmt/Application</exclude>
+                                <exclude>**/edu/wgu/osmt/ImportCommandRunner</exclude>
+                                <exclude>**/edu/wgu/osmt/security/SecurityConfig**</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>${flywaydb.version}</version>


### PR DESCRIPTION
The Spring app is excluded from an artifact with the "lib" classifer,
i.e., "osmt-api-1.1.1-SNAPSHOT-lib.jar".

This artifact can be declared as a dependency for another Spring application.