### PR TITLE
fixed bug were it would make multiple xhr requests

### DIFF
--- a/ui/angular.json
+++ b/ui/angular.json
@@ -87,6 +87,14 @@
                   "maximumError": "4kb"
                 }
               ]
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
             }
           }
         },
@@ -99,8 +107,12 @@
           "configurations": {
             "production": {
               "browserTarget": "ui:build:production"
+            },
+            "development": {
+              "browserTarget": "ui:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -6,7 +6,7 @@ import {ApiTaskResult, ITaskResult} from "./task/ApiTaskResult"
 import {PublishStatus} from "./PublishStatus"
 import {ApiSortOrder} from "./richskill/ApiSkill"
 import {ApiSearch} from "./richskill/service/rich-skill-search.service"
-import {map, share} from "rxjs/operators"
+import {map, share, shareReplay} from "rxjs/operators"
 import {Router} from "@angular/router"
 import {Location} from "@angular/common"
 
@@ -56,7 +56,7 @@ export abstract class AbstractService {
     const observable = this.httpClient.get<T>(this.buildUrl(path), {
       headers: this.wrapHeaders(headers),
       params,
-      observe: "response"}).pipe(share())
+      observe: "response"}).pipe(shareReplay())
     observable
       .subscribe(() => {}, (err) => { this.redirectToLogin(err) })
     return observable
@@ -65,7 +65,7 @@ export abstract class AbstractService {
     const observable =  this.httpClient.post<T>(this.buildUrl(path), body, {
       headers: this.wrapHeaders(headers),
       params,
-      observe: "response"}).pipe(share())
+      observe: "response"}).pipe(shareReplay())
     observable
       .subscribe(() => {}, (err) => { this.redirectToLogin(err) })
     return observable

--- a/ui/src/app/richskill/service/rich-skill.service.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.ts
@@ -141,7 +141,6 @@ export class RichSkillService extends AbstractService {
       params,
       body: apiSearch,
     })
-      .pipe(share())
       .pipe(map(({body, headers}) => {
         const totalCount = Number(headers.get("X-Total-Count"))
         const skills = body?.map(skill => skill) || []


### PR DESCRIPTION
found that with multiple subscribers to an observable it would remit the execution chain aka send xhr requests. We were using share method but share we were using it incorrectly. After reading the docs, shareReplay method allows for the replaying of values that was returned from the observable without making a costly xhr request for any amount of subscribres.