### PR TITLE
Updating parent POM with a newer version of the Javadocs library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
We faced an issue trying to build locally the project so we needed to update this library to avoid this incompatibility with current Maven version