### PR TITLE
Updating opencsv dependency version

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.2</version>
+            <version>5.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bumping up opencsv dependency version to avoid vulnerabilities
![image](https://user-images.githubusercontent.com/115018284/197781328-24f0b775-ff25-41d8-9148-4aa33d661bb2.png)
