### PR TITLE
OSMT-118 API patching

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -260,7 +260,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
-            <version>2.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.ehcache</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <kotlin.version>1.5.10</kotlin.version>
+        <kotlin.version>1.7.21</kotlin.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.coroutines.version>1.5.1</kotlin.coroutines.version>
         <exposed.version>0.24.1</exposed.version>
@@ -41,7 +41,7 @@
 <!--        TODO - is this needed?-->
         <kotest.version>4.1.3</kotest.version>
         <start-class>edu.wgu.osmt.ApplicationKt</start-class>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <spring-data-elasticsearch.version>4.4.1</spring-data-elasticsearch.version>
         <ehcache.version>3.9.2</ehcache.version>
         <log4j.version>2.17.1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.7</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
Bumping **kotlin** dependency version up from 1.5.10 to 1.7.21, Some of the new features are:

- Improved support for Lombok and support for JSpecify
- Gradle: Java toolchain support and improved daemon configuration
- An incremental release with new language features
- Support for several compiler plugins in the Kotlin K2 compiler
- New Kotlin/Native memory manager enabled by default
- Support for Gradle 7.1

Bumping **testcontainers**  dependency version up from 1.15.3 to 1.17.6, Some of the new features are:

- Better M1 Mac compatibility
- Better startup performance for all containers
- Host port access for containers
- Better Oracle Database support
- Some Bug Fixes

Bumping **spring-boot-starter-parent** version up from 2.7.1 to 2.7.7
