### PR TITLE
Feature/osmt 10 export draft collection

### DIFF
--- a/api/src/main/kotlin/edu/wgu/osmt/collection/CollectionController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/collection/CollectionController.kt
@@ -157,7 +157,12 @@ class CollectionController @Autowired constructor(
         @PathVariable uuid: String
     ): HttpEntity<TaskResult> {
         val task = CsvTask(collectionUuid = uuid)
-        taskMessageService.enqueueJob(TaskMessageService.skillsForCollectionCsv, task)
+        if((collectionRepository.findByUUID(uuid)!!.publishStatus() == PublishStatus.Draft)) {
+            taskMessageService.enqueueJob(TaskMessageService.skillsForDraftCollectionCsv, task)
+        }
+        else if((collectionRepository.findByUUID(uuid)!!.publishStatus() == PublishStatus.Published)) {
+            taskMessageService.enqueueJob(TaskMessageService.skillsForCollectionCsv, task)
+        }
         return Task.processingResponse(task)
     }
 

--- a/api/src/main/kotlin/edu/wgu/osmt/collection/CsvTaskProcessor.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/collection/CsvTaskProcessor.kt
@@ -2,6 +2,7 @@ package edu.wgu.osmt.collection
 
 import com.github.sonus21.rqueue.annotation.RqueueListener
 import edu.wgu.osmt.config.AppConfig
+import edu.wgu.osmt.db.PublishStatus
 import edu.wgu.osmt.richskill.RichSkillAndCollections
 import edu.wgu.osmt.richskill.RichSkillCsvExport
 import edu.wgu.osmt.richskill.RichSkillDescriptorDao
@@ -46,6 +47,28 @@ class CsvTaskProcessor {
 
         val csv = collectionRepository.findByUUID(csvTask.collectionUuid)
             ?.skills
+            ?.with(RichSkillDescriptorDao::collections)
+            ?.map { RichSkillAndCollections.fromDao(it) }
+            ?.let { RichSkillCsvExport(appConfig).toCsv(it) }
+
+        taskMessageService.publishResult(
+            csvTask.copy(result = csv, status = TaskStatus.Ready)
+        )
+        logger.info("Task ${csvTask.uuid} completed")
+    }
+
+    @RqueueListener(
+        value = [TaskMessageService.skillsForDraftCollectionCsv],
+        deadLetterQueueListenerEnabled = "true",
+        deadLetterQueue = TaskMessageService.deadLetters,
+        concurrency = "1"
+    )
+    fun csvSkillsInDraftCollectionProcessor(csvTask: CsvTask) {
+        logger.info("Started processing draft collection to csv with task id: ${csvTask.uuid}")
+
+        val csv = collectionRepository.findByUUID(csvTask.collectionUuid)
+            ?.skills
+            ?.filter { PublishStatus.Archived != it.publishStatus() }
             ?.with(RichSkillDescriptorDao::collections)
             ?.map { RichSkillAndCollections.fromDao(it) }
             ?.let { RichSkillCsvExport(appConfig).toCsv(it) }

--- a/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
@@ -10,6 +10,7 @@ import edu.wgu.osmt.RoutePaths.COLLECTION_PUBLISH
 import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS
 import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS_UPDATE
 import edu.wgu.osmt.RoutePaths.COLLECTION_UPDATE
+import edu.wgu.osmt.RoutePaths.ES_ADMIN
 import edu.wgu.osmt.RoutePaths.SEARCH_COLLECTIONS
 import edu.wgu.osmt.RoutePaths.SEARCH_JOBCODES_PATH
 import edu.wgu.osmt.RoutePaths.SEARCH_KEYWORDS_PATH
@@ -90,7 +91,7 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             .mvcMatchers(GET, COLLECTION_DETAIL).permitAll()
 
             .mvcMatchers(POST, COLLECTION_SKILLS).permitAll()
-            .mvcMatchers(GET, COLLECTION_CSV).permitAll()
+            .mvcMatchers(GET, COLLECTION_CSV).hasRole(appConfig.roleAdmin)
             .mvcMatchers(GET, TASK_DETAIL_TEXT).permitAll()   // public csv results
 
             .and().exceptionHandling().authenticationEntryPoint(returnUnauthorized)

--- a/api/src/main/kotlin/edu/wgu/osmt/task/TaskMessageService.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/task/TaskMessageService.kt
@@ -43,6 +43,7 @@ class TaskMessageService {
         const val publishSkills = "batch-publish-skills"
         const val updateCollectionSkills = "update-collection-skills"
         const val skillsForCollectionCsv = "collection-skills-csv-process"
+        const val skillsForDraftCollectionCsv = "draft-collection-skills-csv-process"
         const val skillsForFullLibraryCsv = "full-library-skills-csv-process"
         const val skillsForCustomListExportCsv = "custom-rsd-list-export"
     }

--- a/ui/src/app/collection/detail/manage-collection.component.spec.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.spec.ts
@@ -276,7 +276,7 @@ describe("ManageCollectionComponent", () => {
 
       // Assert
       expect(actions).toBeTruthy()
-      expect(actions.length).toEqual(4)
+      expect(actions.length).toEqual(5)
 
       let action = actions[0]
       expect(action.label).toEqual("Add RSDs to This Collection")

--- a/ui/src/app/collection/detail/manage-collection.component.spec.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.spec.ts
@@ -10,7 +10,8 @@ import { of } from "rxjs"
 import {
   createMockCollection,
   createMockPaginatedSkills,
-  createMockSkillSummary
+  createMockSkillSummary,
+  csvContent
 } from "../../../../test/resource/mock-data"
 import {
   AuthServiceStub,
@@ -30,6 +31,7 @@ import { ApiCollection } from "../ApiCollection"
 import { CollectionService } from "../service/collection.service"
 import { ManageCollectionComponent } from "./manage-collection.component"
 import {AuthService} from "../../auth/auth-service";
+import * as FileSaver from "file-saver"
 
 
 @Component({
@@ -489,5 +491,32 @@ describe("ManageCollectionComponent", () => {
     // Assert
     expect(component.showingMultipleConfirm).toBeFalsy()
     expect(component.apiSearch).toBeFalsy()
+  })
+
+  it("generateCsv should call getCsv and loader", () => {
+    const spyCollectionService = spyOn(component["collectionService"], "requestCollectionSkillsCsv").and.callThrough()
+    const spyLoaderSubject = spyOn(component["toastService"].loaderSubject, "next")
+    component.generateCsv("My collection")
+    expect(spyCollectionService).toHaveBeenCalled()
+    expect(spyLoaderSubject).toHaveBeenCalledWith(true)
+  })
+
+
+  it("getCsv should call getCsvTaskResultsIfComplete", () => {
+    const collection = {
+      uuid: "fc0a65a6-facd-4f9d-b590-cfecbfe706ad",
+      name: "My Collection"
+    }
+    const spyCollectionService = spyOn(component["collectionService"], "getCsvTaskResultsIfComplete").and.returnValue(of(csvContent))
+    const spySaveCsv = spyOn(component, "saveCsv")
+    component.getCsv(collection.uuid, collection.name)
+    expect(spyCollectionService).toHaveBeenCalledWith(collection.uuid)
+    expect(spySaveCsv).toHaveBeenCalledWith(csvContent.body, collection.name)
+  })
+
+  it("saveCSV should call FileSaver", () => {
+    const spySaveAS = spyOn(FileSaver, "saveAs")
+    component.saveCsv(csvContent.body, "My Collection")
+    expect(spySaveAS).toHaveBeenCalled()
   })
 })

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -143,7 +143,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
   }
 
   generateCsv(): void {
-    this.collectionService.requestCollectionSkillsCsv(this.uuidParam ? this.uuidParam : "")
+    this.collectionService.requestCollectionSkillsCsv(this.uuidParam ?? "")
       .subscribe((taskStarted: ITaskResult) => {
         this.toastService.loaderSubject.next(true)
         this.getCsv(taskStarted.uuid ?? "")
@@ -226,7 +226,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
       )
     }
 
-    if (this.collection?.status === PublishStatus.Draft) {
+    if (this.collection?.status === PublishStatus.Draft || this.collection?.status === PublishStatus.Published) {
       actions.push(new TableActionDefinition({
         label: "Download CSV",
         icon: this.downloadIcon,

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -231,7 +231,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
         label: "Download CSV",
         icon: this.downloadIcon,
         callback: () => this.generateCsv(this.collection?.name ?? ""),
-        visible: () => true
+        visible: () => this.authService.isEnabledByRoles(ButtonAction.LibraryExport)
       }))
     }
     return actions

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, ViewChild} from "@angular/core"
+import {Component, Inject, LOCALE_ID, OnInit, ViewChild} from "@angular/core"
 import {ApiCollection, ApiCollectionUpdate} from "../ApiCollection"
 import {ApiSearch, ApiSkillListUpdate} from "../../richskill/service/rich-skill-search.service"
 import {ActivatedRoute, Router} from "@angular/router"
@@ -11,11 +11,15 @@ import {SvgHelper, SvgIcon} from "../../core/SvgHelper"
 import {TableActionDefinition} from "../../table/skills-library-table/has-action-definitions"
 import {determineFilters, PublishStatus} from "../../PublishStatus"
 import {ApiSkillSummary} from "../../richskill/ApiSkillSummary"
-import {Observable, Subject} from "rxjs"
+import {Observable, of, Subject, throwError} from "rxjs"
 import {TableActionBarComponent} from "../../table/skills-library-table/table-action-bar.component"
 import {Title} from "@angular/platform-browser";
 import {AuthService} from "../../auth/auth-service";
 import {ButtonAction} from "../../auth/auth-roles";
+import {formatDate} from "@angular/common"
+import * as FileSaver from "file-saver"
+import {ITaskResult} from "../../task/ApiTaskResult"
+import {delay, retryWhen, switchMap} from "rxjs/operators"
 
 @Component({
   selector: "app-manage-collection",
@@ -30,6 +34,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
 
   editIcon = SvgHelper.path(SvgIcon.EDIT)
   publishIcon = SvgHelper.path(SvgIcon.PUBLISH)
+  downloadIcon = SvgHelper.path(SvgIcon.DOWNLOAD)
   archiveIcon = SvgHelper.path(SvgIcon.ARCHIVE)
   unarchiveIcon = SvgHelper.path(SvgIcon.UNARCHIVE)
   addIcon = SvgHelper.path(SvgIcon.ADD)
@@ -60,6 +65,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
               protected route: ActivatedRoute,
               protected titleService: Title,
               protected authService: AuthService,
+              @Inject(LOCALE_ID) protected locale: string
   ) {
     super(router, richSkillService, toastService, authService)
   }
@@ -136,6 +142,38 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
     return false
   }
 
+  generateCsv(): void {
+    this.collectionService.requestCollectionSkillsCsv(this.uuidParam ? this.uuidParam : "")
+      .subscribe((taskStarted: ITaskResult) => {
+        this.toastService.loaderSubject.next(true)
+        this.getCsv(taskStarted.uuid ?? "")
+      })
+  }
+
+  getCsv(uuid: string): void {
+    this.collectionService.getCsvTaskResultsIfComplete(uuid)
+      .pipe(
+        retryWhen(errors => errors.pipe(
+          switchMap((error) => {
+            if (error.status === 404) {
+              return of(error.status)
+            }
+            return throwError(error)
+          }),
+          delay(1000),
+        )))
+      .subscribe(response => {
+        this.saveCsv(response.body)
+      })
+  }
+
+  saveCsv(body: string): void {
+    const blob = new Blob([body], {type: "text/csv;charset=utf-8;"})
+    const date = formatDate(new Date(), "yyyy-MM-dd", this.locale)
+    FileSaver.saveAs(blob, `RSD Skills - ${date}.csv`)
+    this.toastService.loaderSubject.next(false)
+  }
+
   actionDefinitions(): TableActionDefinition[] {
     const actions = [
       new TableActionDefinition({
@@ -186,6 +224,15 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
           visible: () => this.authService.isEnabledByRoles(ButtonAction.CollectionUpdate)
         })
       )
+    }
+
+    if (this.collection?.status === PublishStatus.Draft) {
+      actions.push(new TableActionDefinition({
+        label: "Download CSV",
+        icon: this.downloadIcon,
+        callback: () => this.generateCsv(),
+        visible: () => true
+      }))
     }
     return actions
   }

--- a/ui/src/app/collection/detail/manage-collection.component.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.ts
@@ -142,15 +142,15 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
     return false
   }
 
-  generateCsv(): void {
+  generateCsv(collectionName: string): void {
     this.collectionService.requestCollectionSkillsCsv(this.uuidParam ?? "")
       .subscribe((taskStarted: ITaskResult) => {
         this.toastService.loaderSubject.next(true)
-        this.getCsv(taskStarted.uuid ?? "")
+        this.getCsv(taskStarted.uuid ?? "", collectionName)
       })
   }
 
-  getCsv(uuid: string): void {
+  getCsv(uuid: string, collectionName: string): void {
     this.collectionService.getCsvTaskResultsIfComplete(uuid)
       .pipe(
         retryWhen(errors => errors.pipe(
@@ -163,14 +163,14 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
           delay(1000),
         )))
       .subscribe(response => {
-        this.saveCsv(response.body)
+        this.saveCsv(response.body, collectionName)
       })
   }
 
-  saveCsv(body: string): void {
+  saveCsv(body: string, collectionName: string): void {
     const blob = new Blob([body], {type: "text/csv;charset=utf-8;"})
     const date = formatDate(new Date(), "yyyy-MM-dd", this.locale)
-    FileSaver.saveAs(blob, `RSD Skills - ${date}.csv`)
+    FileSaver.saveAs(blob, `RSD Skills - ${collectionName} - ${date}.csv`)
     this.toastService.loaderSubject.next(false)
   }
 
@@ -230,7 +230,7 @@ export class ManageCollectionComponent extends SkillsListComponent implements On
       actions.push(new TableActionDefinition({
         label: "Download CSV",
         icon: this.downloadIcon,
-        callback: () => this.generateCsv(),
+        callback: () => this.generateCsv(this.collection?.name ?? ""),
         visible: () => true
       }))
     }

--- a/ui/test/resource/mock-data.ts
+++ b/ui/test/resource/mock-data.ts
@@ -292,3 +292,5 @@ export const mockTaskResultForExportSearch: ApiTaskResult = {
   id: "/api/results/batch/77574cd6-933b-4ee0-a106-afadb7a3a292"
 }
 
+export const csvContent = {body: "value1,value2,value3"}
+


### PR DESCRIPTION
# UI Changes
- New button to download draft or published collections.

<img width="1437" alt="Screenshot 2023-01-13 at 11 30 07" src="https://user-images.githubusercontent.com/68391066/212382288-ed671370-105a-43a4-9750-1f1118780489.png">
<img width="1437" alt="Screenshot 2023-01-13 at 11 32 22" src="https://user-images.githubusercontent.com/68391066/212382544-616fc258-eb44-4f12-9803-4e88882791ec.png">
<br>
<br>
<hr>

- Download CSV is not available to download archived collections.
<img width="1437" alt="Screenshot 2023-01-13 at 11 40 33" src="https://user-images.githubusercontent.com/68391066/212385128-14f87691-886a-467e-afba-eba97f13d6c6.png">
<img width="1437" alt="Screenshot 2023-01-13 at 11 40 57" src="https://user-images.githubusercontent.com/68391066/212385181-c360e6eb-b616-43de-8e41-d0f2fb67def4.png">
<br>
<br>
<hr>

- Button is not visible if you don't have admin role
<img width="1437" alt="Screenshot 2023-01-13 at 11 44 06" src="https://user-images.githubusercontent.com/68391066/212386393-9697ab3a-74f0-4ef3-86d2-4be6745ebbdb.png">
<br>
<br>
<hr>

- The name of the downloaded file is "RSD Skills - ${collectionName} - ${date}.csv"
<img width="700" alt="Screenshot 2023-01-13 at 11 46 47" src="https://user-images.githubusercontent.com/68391066/212386309-37dbf281-74b6-4f7c-b909-7da08e99825b.png">

