### PR TITLE
Export selected button only on search

### DIFF
--- a/ui/src/app/richskill/list/skills-list.component.spec.ts
+++ b/ui/src/app/richskill/list/skills-list.component.spec.ts
@@ -388,32 +388,30 @@ describe("SkillsListComponent", () => {
     expect(action3.callback?.(action3, skill3)).toBeFalsy()  // Always false
     expect(action3.visible?.(skill3)).toBeFalsy()  // != Archived
 
-    const actionExportSelected = tableActions[4]
-    expect(actionExportSelected.label).toEqual("Export Selected")
 
     component.selectedSkills = [
       createMockSkillSummary("id1", PublishStatus.Draft),
     ]
     component.showAddToCollection = true
     tableActions = component.tableActions()
-    let skill5 = createMockSkillSummary("id4", PublishStatus.Archived)
-    let action5 = tableActions[5]
-    expect(action5.label).toEqual("Add to Collection")
-    expect(action5 && action5.callback).toBeTruthy()
-    expect(action5.callback?.(action5, skill5)).toBeFalsy()  // Always false
-    expect(action5.visible?.(skill5)).toBeTruthy()  // There are selected skills
+    let skill4 = createMockSkillSummary("id4", PublishStatus.Archived)
+    let action4 = tableActions[4]
+    expect(action4.label).toEqual("Add to Collection")
+    expect(action4 && action4.callback).toBeTruthy()
+    expect(action4.callback?.(action4, skill4)).toBeFalsy()  // Always false
+    expect(action4.visible?.(skill4)).toBeTruthy()  // There are selected skills
 
     component.selectedSkills = [
       createMockSkillSummary("id1", PublishStatus.Draft),
     ]
     component.showAddToCollection = false
     tableActions = component.tableActions()
-    skill5 = createMockSkillSummary("id4", PublishStatus.Archived)
-    action5 = tableActions[5]
-    expect(action5.label).toEqual("Remove from Collection")
-    expect(action5 && action5.callback).toBeTruthy()
-    expect(action5.callback?.(action5, skill5)).toBeFalsy()  // Always false
-    expect(action5.visible?.(skill5)).toBeTruthy()  // There are selected skills
+    skill4 = createMockSkillSummary("id4", PublishStatus.Archived)
+    action4 = tableActions[4]
+    expect(action4.label).toEqual("Remove from Collection")
+    expect(action4 && action4.callback).toBeTruthy()
+    expect(action4.callback?.(action4, skill4)).toBeFalsy()  // Always false
+    expect(action4.visible?.(skill4)).toBeTruthy()  // There are selected skills
   })
 
   it("getSelectedSkills should be correct", () => {

--- a/ui/src/app/richskill/list/skills-list.component.ts
+++ b/ui/src/app/richskill/list/skills-list.component.ts
@@ -42,6 +42,7 @@ export class SkillsListComponent extends QuickLinksHelper {
   showLibraryEmptyMessage = false
 
   showAddToCollection = true
+  showExportSelected = false
 
   constructor(protected router: Router,
               protected richSkillService: RichSkillService,
@@ -231,14 +232,17 @@ export class SkillsListComponent extends QuickLinksHelper {
         icon: "unarchive",
         callback: (action: TableActionDefinition, skill?: ApiSkillSummary) => this.handleClickUnarchive(action, skill),
         visible: (skill?: ApiSkillSummary) => this.unarchiveVisible(skill)
-      }),
-      new TableActionDefinition({
+      })
+    ]
+
+    if (this.showExportSelected) {
+      actions.push(new TableActionDefinition({
         label: "Export Selected",
         icon: "download",
         callback: (action: TableActionDefinition, kill?: ApiSkillSummary) => this.handleClickExportSearch(),
         visible: () => this.exportSearchVisible()
-      })
-    ]
+      }))
+    }
 
     if (this.showAddToCollection) {
       actions.push(new TableActionDefinition({

--- a/ui/src/app/search/rich-skill-search-results.component.spec.ts
+++ b/ui/src/app/search/rich-skill-search-results.component.spec.ts
@@ -91,6 +91,13 @@ describe("RichSkillSearchResultsComponent", () => {
     expect(component).toBeTruthy()
   })
 
+  it("table actions should be correct", () => {
+    const tableActions = component.tableActions()
+    const actionExportSelected = tableActions[4]
+    expect(actionExportSelected.label).toEqual("Export Selected")
+    expect(tableActions.length).toEqual(6)
+  })
+
   it("should handle empty search query", () => {
     // Arrange
     const query = "some query"

--- a/ui/src/app/search/rich-skill-search-results.component.ts
+++ b/ui/src/app/search/rich-skill-search-results.component.ts
@@ -27,6 +27,7 @@ export class RichSkillSearchResultsComponent extends SkillsListComponent impleme
 
   selectAllChecked = false
   showSearchEmptyMessage = true
+  showExportSelected = true
   private multiplePagesSelected: boolean = false
 
   constructor(protected router: Router,


### PR DESCRIPTION
- You can see export selected  buttononly when you do a search.
<img width="1504" alt="Screenshot 2023-01-17 at 16 32 22" src="https://user-images.githubusercontent.com/68391066/213026913-3c6b20e5-07b7-4002-b264-fd9e1ccbd9be.png">
<img width="1504" alt="Screenshot 2023-01-17 at 16 32 28" src="https://user-images.githubusercontent.com/68391066/213026921-d1ead4fd-b6a8-4c3c-af0e-e461683aefee.png">

<hr>
<hr>
The button is not displayed when there is no a search.
<img width="1504" alt="Screenshot 2023-01-17 at 16 32 35" src="https://user-images.githubusercontent.com/68391066/213027089-2715e453-9e29-4d03-8d30-90c090b3b3b7.png">
<img width="1504" alt="Screenshot 2023-01-17 at 16 32 52" src="https://user-images.githubusercontent.com/68391066/213027105-4e00896c-8217-4d8a-90df-52b2150b4e19.png">
