### PR TITLE
OSMT-299: Added 'Copy Public URL' to manage RSD action bar.

### DIFF
--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.html
@@ -78,6 +78,18 @@
     </button>
   </ng-template>
 
+  <button type="button" class="m-actionBarItem" (click)="handleCopyPublicURL()">
+      <span class="m-actionBarItem-x-icon">
+        <svg class="t-icon" aria-hidden="true">
+          <use [attr.xlink:href]="duplicateIcon"></use>
+        </svg>
+      </span>
+    <span class="m-actionBarItem-x-text">Copy Public URL</span>
+    <label>
+      <textarea class="t-visuallyHidden" #fullPath>{{skillPublicUrl}}</textarea>
+    </label>
+  </button>
+
   <button type="button" class="m-actionBarItemHorizontal m-actionBarItemHorizontal" [disabled]="!canSkillCreate">
     <svg class="m-actionBarItemHorizontal-x-icon t-icon">
       <use [attr.xlink:href]="dismissIcon"></use>

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.spec.ts
@@ -18,6 +18,7 @@ import { ManageSkillActionBarHorizontalComponent } from "./manage-skill-action-b
     <app-manage-skill-action-bar-horizontal
       [skillUuid]="mySkillUuid"
       [skillName]="mySkillName"
+      [skillPublicUrl]="mySkillPublicUrl"
       [archived]="myArchived"
       [published]="myPublished">
     </app-manage-skill-action-bar-horizontal>`
@@ -25,6 +26,7 @@ import { ManageSkillActionBarHorizontalComponent } from "./manage-skill-action-b
 class TestHostComponent {
   mySkillUuid = "1234"
   mySkillName = "my skill name"
+  mySkillPublicUrl = "mockUrl"
   myArchived = false
   myPublished = false
 }

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-horizontal/manage-skill-action-bar-horizontal.component.ts
@@ -13,6 +13,7 @@ export class ManageSkillActionBarHorizontalComponent extends ManageRichSkillActi
 
   @Input() skillUuid = ""
   @Input() skillName = ""
+  @Input() skillPublicUrl = ""
   @Input() archived = undefined
   @Input() published = undefined
 

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.html
@@ -55,5 +55,17 @@
       </button>
 
     </ng-template>
+
+    <button type="button" class="m-actionBarItem" (click)="handleCopyPublicURL()">
+      <span class="m-actionBarItem-x-icon">
+        <svg class="t-icon" aria-hidden="true">
+          <use [attr.xlink:href]="duplicateIcon"></use>
+        </svg>
+      </span>
+      <span class="m-actionBarItem-x-text">Copy Public URL</span>
+      <label>
+        <textarea class="t-visuallyHidden" #fullPath>{{skillPublicUrl}}</textarea>
+      </label>
+    </button>
   </div>
 </div>

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.spec.ts
@@ -21,6 +21,7 @@ import any = jasmine.any
     <app-manage-skill-action-bar-vertical
       [skillUuid]="mySkillUuid"
       [skillName]="mySkillName"
+      [skillPublicUrl]="mySkillPublicUrl"
       [archived]="myArchived"
       [published]="myPublished">
     </app-manage-skill-action-bar-vertical>`
@@ -28,6 +29,7 @@ import any = jasmine.any
 class TestHostComponent {
   mySkillUuid = "1234"
   mySkillName = "my skill name"
+  mySkillPublicUrl = "mockUrl"
   myArchived = false
   myPublished = false
 }
@@ -56,6 +58,8 @@ let childComponent: ManageSkillActionBarVerticalComponent
 
 
 describe("ManageSkillActionBarVerticalComponent", () => {
+  let toastService: ToastService
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -79,6 +83,8 @@ describe("ManageSkillActionBarVerticalComponent", () => {
 
     const appConfig = TestBed.inject(AppConfig)
     AppConfig.settings = appConfig.defaultConfig()  // This avoids the race condition on reading the config's whitelabel.toolName
+
+    toastService = TestBed.inject(ToastService)
 
     createComponent(TestHostComponent)
   }))
@@ -155,6 +161,7 @@ describe("ManageSkillActionBarVerticalComponent", () => {
     childComponent.reloadSkill.pipe(first()).subscribe(
       () => { clicked = true; return }
     )
+
     spyOn(window, "confirm").and.returnValue(true)
 
     // Act
@@ -162,5 +169,20 @@ describe("ManageSkillActionBarVerticalComponent", () => {
 
     // Assert
     expect(clicked).toBeTruthy()
+  })
+
+  it("handleCopyPublicUrl should return", async (done) => {
+    // Arrange
+    let clipboardWriteTextSpy = spyOn(navigator.clipboard, "writeText").and.returnValue(Promise.resolve())
+    let showToastSpy = spyOn(toastService, "showToast").and.callFake(() => { done() })
+
+    // Act
+    childComponent.handleCopyPublicURL()
+
+    await clipboardWriteTextSpy
+
+    // Assert
+    expect(clipboardWriteTextSpy).toHaveBeenCalledWith("mockUrl")
+    expect(showToastSpy).toHaveBeenCalledWith("Success!", "URL copied to clipboard")
   })
 })

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/action-bar-vertical/manage-skill-action-bar-vertical.component.ts
@@ -15,6 +15,7 @@ export class ManageSkillActionBarVerticalComponent extends ManageRichSkillAction
 
   @Input() skillUuid = ""
   @Input() skillName = ""
+  @Input() skillPublicUrl = ""
   @Input() archived = undefined
   @Input() published = undefined
 

--- a/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/action-bar/manage-rich-skill-action-bar.component.ts
@@ -15,6 +15,7 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
 
   abstract skillUuid: string
   abstract skillName: string
+  abstract skillPublicUrl: string
   abstract archived: string | undefined
   abstract published: string | undefined
 
@@ -125,6 +126,16 @@ export abstract class ManageRichSkillActionBarComponent implements OnInit {
       const url = `skills/${this.skillUuid}`
       window.open(url, "_blank")
     }
+  }
+
+  handleCopyPublicURL(): void {
+    navigator.clipboard.writeText(this.skillPublicUrl)
+      .then(
+        () => this.toastService.showToast("Success!", "URL copied to clipboard")
+      )
+      .catch(
+        () => this.toastService.showToast("Error", "Could not copy to clipboard")
+      )
   }
 
   setEnableFlags(): void {

--- a/ui/src/app/richskill/detail/rich-skill-manage/rich-skill-manage.component.html
+++ b/ui/src/app/richskill/detail/rich-skill-manage/rich-skill-manage.component.html
@@ -29,6 +29,7 @@
         <app-manage-skill-action-bar-vertical
           [skillUuid]="getSkillUuid()"
           [skillName]="getSkillName()"
+          [skillPublicUrl]="getSkillUrl()"
           [archived]="getArchivedDate()"
           [published]="getPublishedDate()"
           (reloadSkill)="loadSkill()"
@@ -47,6 +48,7 @@
     <app-manage-skill-action-bar-horizontal
       [skillUuid]="getSkillUuid()"
       [skillName]="getSkillName()"
+      [skillPublicUrl]="getSkillUrl()"
       [archived]="getArchivedDate()"
       [published]="getPublishedDate()"
       (reloadSkill)="loadSkill()"


### PR DESCRIPTION
Created item in action bar of manage skill page with label 'Copy Public URL'. This button uses places the same URL as the button on the public skill page on to the clipboard.