### PR TITLE
Update rqueue-spring-boot-starter to 2.13.0-RELEASE

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.github.sonus21</groupId>
             <artifactId>rqueue-spring-boot-starter</artifactId>
-            <version>2.10.1-RELEASE</version>
+            <version>2.13.0-RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Patching for CVE: CVE-2022-37767
- Library: pebble-3.1.5.jar
- Vulnerable version: 3.1.5
- Patched Version: 3.1.6 or 3.2.0

  edu.wgu.osmt:osmt-api:jar:2.5.0-SNAPSHOT
   \- com.github.sonus21:rqueue-spring-boot-starter:jar:2.13.0-RELEASE:compile
     \- com.github.sonus21:rqueue-core:jar:2.13.0-RELEASE:compile
       \- io.pebbletemplates:pebble-spring5:jar:3.1.6:compile 
         \- io.pebbletemplates:pebble:jar:3.1.6:compile