### PR TITLE
OSMT-300: Show categories with totals on collection detail pages.

### DIFF
--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/Keyword.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/Keyword.kt
@@ -70,6 +70,11 @@ data class KeywordUpdateObj(
     }
 }
 
+data class KeywordCount(
+    val keyword: Any,
+    val count: Int
+)
+
 object KeywordTable : LongIdTable("Keyword"), TableWithUpdate<KeywordUpdateObj> {
     override val creationDate = datetime("creationDate")
     override val updateDate = datetime("updateDate")

--- a/api/src/test/kotlin/edu/wgu/osmt/api/model/ApiCollectionTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/api/model/ApiCollectionTest.kt
@@ -22,7 +22,7 @@ internal class ApiCollectionTest {
         val col = mockData.getCollection(1)
 
         // Act
-        val api = col?.let { ApiCollection(it, ArrayList(), mockData.appConfig) }
+        val api = col?.let { ApiCollection(it, ArrayList(), mapOf(), mockData.appConfig) }
 
         // Assert
         Assertions.assertThat(col?.creationDate).isEqualTo(api?.creationDate?.toLocalDateTime())

--- a/docs/int/osmt-v2.x-openapi3.yaml
+++ b/docs/int/osmt-v2.x-openapi3.yaml
@@ -1347,6 +1347,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SkillSummary'
+        skillKeywords:
+          type: object
+          properties:
+            Alignment:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Author:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Category:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Certification:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Employer:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Keyword:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
+            Standard:
+              type: array
+              items:
+                $ref: '#/components/schemas/KeywordCount'
 
     CollectionDoc:
       type: object
@@ -1654,6 +1685,17 @@ components:
         - alignment
         - employer
         - author
+
+    KeywordCount:
+      type: object
+      properties:
+        keyword:
+          oneOf:
+            - string
+            - $ref: '#/components/schemas/Alignment'
+            - $ref: '#/components/schemas/NamedReference'
+        count:
+          type: number
 
     Change:
       type: object

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -16,6 +16,8 @@ import {HeaderComponent} from "./navigation/header.component"
 import {FooterComponent} from "./navigation/footer.component"
 import {SkillCollectionsDisplayComponent} from "./richskill/form/skill-collections-display.component"
 import {ToastComponent} from "./toast/toast.component"
+import {PillComponent} from "./core/pill/pill.component";
+import {PillGroupComponent} from "./core/pill/group/pill-group.component";
 import {AuthService} from "./auth/auth-service"
 import {AuthGuard} from "./auth/auth.guard"
 import {CommoncontrolsComponent} from "./navigation/commoncontrols.component"
@@ -126,6 +128,8 @@ export function initializeApp(
     LogoutComponent,
     LoginComponent,
     LoginSuccessComponent,
+    PillComponent,
+    PillGroupComponent,
 
     // Rich skill form
     RichSkillFormComponent,

--- a/ui/src/app/collection/ApiCollection.ts
+++ b/ui/src/app/collection/ApiCollection.ts
@@ -1,5 +1,6 @@
 import {PublishStatus} from "../PublishStatus"
 import {IStringListUpdate} from "../richskill/ApiSkillUpdate"
+import {KeywordCount, KeywordType} from "../richskill/ApiSkill";
 
 export interface ICollection {
   archiveDate?: Date
@@ -12,6 +13,7 @@ export interface ICollection {
   workspaceOwner?: string
   publishDate?: Date
   skills: string[]
+  skillKeywords?: Map<KeywordType, KeywordCount[]>
   status: PublishStatus
   updateDate?: Date
   uuid: string
@@ -28,6 +30,7 @@ export class ApiCollection {
   publishDate?: Date
   workspaceOwner?: string
   skills: string[]
+  skillKeywords?: Map<KeywordType, KeywordCount[]>
   status: PublishStatus
   updateDate?: Date
   uuid: string
@@ -44,6 +47,7 @@ export class ApiCollection {
       workspaceOwner,
       publishDate,
       skills,
+      skillKeywords,
       status,
       updateDate,
       uuid
@@ -59,6 +63,7 @@ export class ApiCollection {
     this.workspaceOwner = workspaceOwner
     this.publishDate = publishDate
     this.skills = skills
+    this.skillKeywords = skillKeywords
     this.status = status
     this.updateDate = updateDate
     this.uuid = uuid

--- a/ui/src/app/collection/detail/collection-public/collection-public.component.html
+++ b/ui/src/app/collection/detail/collection-public/collection-public.component.html
@@ -28,6 +28,11 @@
 
   <div class="l-container">
 
+    <div class="t-margin-medium">
+      <div class="t-margin-small"><b>Categories</b></div>
+      <app-pill-group [pillControls]="skillCategories"></app-pill-group>
+    </div>
+
     <app-size-pagination
       [isVisible]="isSizePaginationVisible"
       [currentSize]="size"

--- a/ui/src/app/collection/detail/collection-public/collection-public.component.spec.ts
+++ b/ui/src/app/collection/detail/collection-public/collection-public.component.spec.ts
@@ -132,6 +132,14 @@ describe("CollectionPublicComponent", () => {
     expect(component.results).toEqual(expected)
   })
 
+  it("updateSkillCategories should be correct", () => {
+    const collection = component.collection
+    component.skillCategories = []
+    component.updateSkillCategories()
+    expect(component.skillCategories[0]).toBeTruthy()
+  })
+
+
   it("handleHeaderColumnSort should be correct", () => {
     // Arrange
     const expected = createMockPaginatedSkills()

--- a/ui/src/app/collection/detail/collection-public/collection-public.component.ts
+++ b/ui/src/app/collection/detail/collection-public/collection-public.component.ts
@@ -5,13 +5,14 @@ import {ActivatedRoute, Router} from "@angular/router"
 import {ToastService} from "../../../toast/toast.service"
 import {CollectionService} from "../../service/collection.service"
 import {Observable} from "rxjs"
-import {ApiSortOrder} from "../../../richskill/ApiSkill"
+import {ApiSortOrder, KeywordType} from "../../../richskill/ApiSkill"
 import {PublishStatus} from "../../../PublishStatus"
 import {ApiCollection} from "../../ApiCollection"
 import {Title} from "@angular/platform-browser";
 import {Whitelabelled} from "../../../../whitelabel";
 import {FormControl} from "@angular/forms"
 import {SizePaginationComponent} from "../../../table/skills-library-table/size-pagination/size-pagination.component"
+import {KeywordCountPillControl} from "../../../core/pill/pill-control";
 
 @Component({
   selector: "app-collection-public",
@@ -23,6 +24,7 @@ export class CollectionPublicComponent extends Whitelabelled implements OnInit {
   title = "Collection"
   uuidParam: string | null
   collection: ApiCollection | undefined
+  skillCategories: KeywordCountPillControl[] = []
   apiSearch: ApiSearch = new ApiSearch({})
 
   resultsLoaded: Observable<PaginatedSkills> | undefined
@@ -51,6 +53,7 @@ export class CollectionPublicComponent extends Whitelabelled implements OnInit {
     this.collectionService.getCollectionByUUID(this.uuidParam ?? "").subscribe(collection => {
       this.titleService.setTitle(`${collection.name} | Collection | ${this.whitelabel.toolName}`)
       this.collection = collection
+      this.updateSkillCategories()
       this.loadNextPage()
     })
   }
@@ -102,6 +105,11 @@ export class CollectionPublicComponent extends Whitelabelled implements OnInit {
 
   loadNextPage(): void {
     this.loadSkillsInCollection()
+  }
+
+  updateSkillCategories() {
+    const categories = this.collection?.skillKeywords?.get(KeywordType.Category)?.map(c => new KeywordCountPillControl(c))
+    this.skillCategories = (categories) ? categories : []
   }
 
   protected setResults(results: PaginatedSkills): void {

--- a/ui/src/app/collection/detail/manage-collection.component.html
+++ b/ui/src/app/collection/detail/manage-collection.component.html
@@ -46,6 +46,11 @@
           </form>
         </div>
 
+        <div class="t-margin-medium">
+          <div class="t-margin-small"><b>Categories</b></div>
+          <app-pill-group [pillControls]="skillCategories" (pillClicked)="handleCategoryClicked($event)"></app-pill-group>
+        </div>
+
         <app-filter-controls
           (changeValue)="sizeChange($event)"
           [isSizePaginationVisible]="isSizePaginationVisible"

--- a/ui/src/app/collection/detail/manage-collection.component.html
+++ b/ui/src/app/collection/detail/manage-collection.component.html
@@ -46,8 +46,8 @@
           </form>
         </div>
 
-        <div class="t-margin-medium">
-          <div class="t-margin-small"><b>Categories</b></div>
+        <div class="t-margin-medium" *ngIf="skillCategories.length">
+          <div class="t-margin-small"><b>Categories represented:</b></div>
           <app-pill-group [pillControls]="skillCategories" (pillClicked)="handleCategoryClicked($event)"></app-pill-group>
         </div>
 

--- a/ui/src/app/collection/detail/manage-collection.component.spec.ts
+++ b/ui/src/app/collection/detail/manage-collection.component.spec.ts
@@ -35,6 +35,8 @@ import * as Auth from "../../auth/auth-roles"
 import {CollectionsLibraryComponent} from "../../table/collections-library.component"
 import {FormControl, FormGroup} from "@angular/forms"
 import {ITableActionDefinitionSubMenu} from "../../table/skills-library-table/has-action-definitions"
+import { KeywordCount } from "../../richskill/ApiSkill";
+import { KeywordCountPillControl } from "../../core/pill/pill-control";
 
 
 @Component({
@@ -133,6 +135,13 @@ describe("ManageCollectionComponent", () => {
 
     // Assert
     expect(component.collection).toEqual(collection)
+  })
+
+  it("updateSkillCategories should be correct", () => {
+    const collection = component.collection
+    component.skillCategories = []
+    component.updateSkillCategories()
+    expect(component.skillCategories[0]).toBeTruthy()
   })
 
   it("loadNextPage should be correct", () => {
@@ -511,6 +520,13 @@ describe("ManageCollectionComponent", () => {
     // Assert
     expect(component.reloadCollection).toHaveBeenCalled()
     expect(component.loadNextPage).toHaveBeenCalled()
+  })
+
+  it("handleCategoryClicked should be correct", () => {
+    const testKwCount = new KeywordCount({ keyword: "test1", count: 8 })
+    expect(component.keywords.categories.length).toEqual(0)
+    component.handleCategoryClicked(new KeywordCountPillControl(testKwCount))
+    expect(component.keywords.categories.length).toEqual(1)
   })
 
   it("handleClickConfirmMulti should be correct", () => {

--- a/ui/src/app/core/pill/group/pill-group.component.html
+++ b/ui/src/app/core/pill/group/pill-group.component.html
@@ -1,11 +1,21 @@
-<ul class="m-pill-group">
-  <li *ngFor="let c of pillControls;">
-    <ng-container *ngIf="hasPillClickedObservers; then withClickedObserver; else withoutClickedObserver"></ng-container>
-    <ng-template #withClickedObserver>
-    <app-pill [control]="c" (clicked)="onPillClicked($event)"></app-pill>
-    </ng-template>
-    <ng-template #withoutClickedObserver>
-    <app-pill [control]="c"></app-pill>
-    </ng-template>
-  </li>
-</ul>
+<div [ngClass]="{'m-pill-group-collapsible': true, collapsed: collapsed}" aria-controls="pill-group-controls" [attr.aria-expanded]="!collapsed && pillControls.length > 20" (click)="expand()">
+  <div class="read-more-wrapper" *ngIf="pillControls.length > 20">
+    <div>
+      <button (click)="toggleCollapse($event)">
+        <span *ngIf="collapsed">Show all {{ pillControls.length }}</span>
+        <span *ngIf="!collapsed">Show fewer</span>
+      </button>
+    </div>
+  </div>
+  <ul id="pill-group-controls" class="m-pill-group">
+    <li *ngFor="let c of pillControls;">
+      <ng-container *ngIf="hasPillClickedObservers; then withClickedObserver; else withoutClickedObserver"></ng-container>
+      <ng-template #withClickedObserver>
+      <app-pill [control]="c" [tabSelectEnabled]="!collapsed" (clicked)="onPillClicked($event)"></app-pill>
+      </ng-template>
+      <ng-template #withoutClickedObserver>
+      <app-pill [control]="c"></app-pill>
+      </ng-template>
+    </li>
+  </ul>
+</div>

--- a/ui/src/app/core/pill/group/pill-group.component.html
+++ b/ui/src/app/core/pill/group/pill-group.component.html
@@ -1,0 +1,11 @@
+<ul class="m-pill-group">
+  <li *ngFor="let c of pillControls;">
+    <ng-container *ngIf="hasPillClickedObservers; then withClickedObserver; else withoutClickedObserver"></ng-container>
+    <ng-template #withClickedObserver>
+    <app-pill [control]="c" (clicked)="onPillClicked($event)"></app-pill>
+    </ng-template>
+    <ng-template #withoutClickedObserver>
+    <app-pill [control]="c"></app-pill>
+    </ng-template>
+  </li>
+</ul>

--- a/ui/src/app/core/pill/group/pill-group.component.spec.ts
+++ b/ui/src/app/core/pill/group/pill-group.component.spec.ts
@@ -1,0 +1,89 @@
+// noinspection LocalVariableNamingConventionJS
+import {HttpClientTestingModule} from "@angular/common/http/testing"
+import {Component, Type} from "@angular/core"
+import {async, ComponentFixture, TestBed} from "@angular/core/testing"
+import {FormsModule, ReactiveFormsModule} from "@angular/forms"
+import {ActivatedRoute, Router} from "@angular/router"
+import {RouterTestingModule} from "@angular/router/testing"
+import {AppConfig} from "src/app/app.config"
+import {EnvironmentService} from "src/app/core/environment.service"
+import {ActivatedRouteStubSpec} from "test/util/activated-route-stub.spec"
+import {TestPillControl, TestPrimaryOnlyPillControl} from "../pill-control.spec";
+import {PillGroupComponent} from "./pill-group.component";
+
+@Component({
+  template: ""
+})
+export abstract class TestHostComponent extends PillGroupComponent<TestPillControl> {
+  constructor() {
+    super();
+
+    this.pillControls = [
+      new TestPillControl(),
+      new TestPrimaryOnlyPillControl()
+    ]
+  }
+}
+
+let activatedRoute: ActivatedRouteStubSpec
+let fixture: ComponentFixture<TestHostComponent>
+let component: TestHostComponent
+
+function createComponent(T: Type<TestHostComponent>): void {
+  fixture = TestBed.createComponent(T)
+  component = fixture.componentInstance
+  fixture.detectChanges()
+  fixture.whenStable().then(() => fixture.detectChanges())
+}
+
+describe("PillGroupComponent", () => {
+  beforeEach(() => {
+    activatedRoute = new ActivatedRouteStubSpec()
+  })
+
+  beforeEach(async(() => {
+    const routerSpy = ActivatedRouteStubSpec.createRouterSpy()
+
+    TestBed.configureTestingModule({
+      declarations: [
+        PillGroupComponent,
+        TestHostComponent
+      ],
+      imports: [
+        FormsModule,  // Required for ([ngModel])
+        ReactiveFormsModule,
+        RouterTestingModule,  // Required for routerLink
+        HttpClientTestingModule,  // Needed to avoid the toolName race condition below
+      ],
+      providers: [
+        AppConfig,  // Needed to avoid the toolName race condition below
+        EnvironmentService,  // Needed to avoid the toolName race condition below
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: Router, useValue: routerSpy },
+      ]
+    }).compileComponents()
+
+    const appConfig = TestBed.inject(AppConfig)
+    AppConfig.settings = appConfig.defaultConfig()  // This avoids the race condition on reading the config's whitelabel.toolName
+
+    activatedRoute.setParams({ userId: 126 })
+
+    // @ts-ignore
+    createComponent(TestHostComponent)
+  }))
+
+  it("should be created", () => {
+    expect(component).toBeTruthy()
+  })
+
+  it("get hasPillClickedObservers should return correct result", () => {
+    expect(component.hasPillClickedObservers).toEqual(false)
+  })
+
+  it("onPillClicked should succeed", () => {
+    expect((() => {
+      component.onPillClicked(component.pillControls[0])
+      return true
+    })()).toEqual(true)
+  })
+})

--- a/ui/src/app/core/pill/group/pill-group.component.ts
+++ b/ui/src/app/core/pill/group/pill-group.component.ts
@@ -1,0 +1,20 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core"
+import {AbstractPillControl} from "../pill-control";
+
+@Component({
+  selector: "app-pill-group",
+  templateUrl: "./pill-group.component.html"
+})
+export class PillGroupComponent<TValue extends AbstractPillControl>{
+
+  @Input() pillControls: TValue[] = []
+  @Output() pillClicked: EventEmitter<TValue> = new EventEmitter()
+
+  get hasPillClickedObservers(): boolean {
+    return this.pillClicked.observers.length > 0
+  }
+
+  onPillClicked(pill: TValue) {
+    this.pillClicked.emit(pill)
+  }
+}

--- a/ui/src/app/core/pill/group/pill-group.component.ts
+++ b/ui/src/app/core/pill/group/pill-group.component.ts
@@ -9,12 +9,23 @@ export class PillGroupComponent<TValue extends AbstractPillControl>{
 
   @Input() pillControls: TValue[] = []
   @Output() pillClicked: EventEmitter<TValue> = new EventEmitter()
+  collapsed = true;
 
   get hasPillClickedObservers(): boolean {
     return this.pillClicked.observers.length > 0
   }
 
-  onPillClicked(pill: TValue) {
+  toggleCollapse(event: Event): void {
+    this.collapsed = !this.collapsed
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  
+  expand(): void {
+    this.collapsed = false
+  }
+
+  onPillClicked(pill: TValue): void {
     this.pillClicked.emit(pill)
   }
 }

--- a/ui/src/app/core/pill/pill-control.spec.ts
+++ b/ui/src/app/core/pill/pill-control.spec.ts
@@ -1,0 +1,100 @@
+import {async, ComponentFixture, TestBed} from "@angular/core/testing"
+import {Injectable} from "@angular/core";
+import {AbstractPillControl, KeywordCountPillControl} from "./pill-control";
+import {KeywordCount} from "../../richskill/ApiSkill";
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TestPillControl extends AbstractPillControl {
+  static readonly TEST_PRIMARY_STRING = "string1"
+  static readonly  TEST_SECONDARY_STRING = "string2"
+  readonly hasSecondaryValue: boolean = true
+
+  get primaryLabel(): string {
+    return TestPillControl.TEST_PRIMARY_STRING
+  }
+
+  get secondaryLabel(): string | undefined {
+    return (this.hasSecondaryValue) ? TestPillControl.TEST_SECONDARY_STRING : undefined
+  }
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TestPrimaryOnlyPillControl extends TestPillControl {
+  readonly hasSecondaryValue: boolean = false
+}
+
+describe("AbstractPillControl", () => {
+
+  let testControl: AbstractPillControl
+  let testPrimaryOnlyControl: AbstractPillControl
+
+  beforeEach(() => {
+    testControl = new TestPillControl()
+    testPrimaryOnlyControl = new TestPrimaryOnlyPillControl()
+  })
+
+  it("should be created", () => {
+    expect(testControl).toBeTruthy()
+    expect(testPrimaryOnlyControl).toBeTruthy()
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(testControl.secondaryLabel).toEqual(TestPillControl.TEST_SECONDARY_STRING)
+    expect(testPrimaryOnlyControl.secondaryLabel).toEqual(undefined)
+  })
+
+  it("get isSelected should return correct result", () => {
+    expect(testControl.isSelected).toEqual(false)
+    testControl.select()
+    expect(testControl.isSelected).toEqual(true)
+    testControl.deselect()
+    expect(testControl.isSelected).toEqual(false)
+  })
+
+  it("deselect should set succeed", () => {
+    testControl.select()
+    expect(testControl.isSelected).toEqual(true)
+    testControl.deselect()
+    expect(testControl.isSelected).toEqual(false)
+  })
+
+  it("select should set succeed", () => {
+    expect(testControl.isSelected).toEqual(false)
+    testControl.select()
+    expect(testControl.isSelected).toEqual(true)
+  })
+})
+
+describe("KeywordCountPillControl", () => {
+
+  const testKwCount: KeywordCount = new KeywordCount({ keyword: "test", count: 5 })
+  let testControl: KeywordCountPillControl
+
+  beforeEach(() => {
+    testControl = new KeywordCountPillControl(testKwCount)
+  })
+
+  it("should be created", () => {
+    expect(testControl).toBeTruthy()
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(testControl.keyword).toEqual(testKwCount.keyword)
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(testControl.count).toEqual(testKwCount.count)
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(testControl.primaryLabel).toEqual(`${testKwCount.keyword}`)
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(testControl.secondaryLabel).toEqual(`${testKwCount.count}`)
+  })
+})

--- a/ui/src/app/core/pill/pill-control.ts
+++ b/ui/src/app/core/pill/pill-control.ts
@@ -1,0 +1,48 @@
+import {IAlignment, INamedReference, KeywordCount} from "../../richskill/ApiSkill";
+
+export abstract class AbstractPillControl {
+
+  private selected: boolean = false
+
+  abstract get primaryLabel(): string
+
+  get secondaryLabel(): string|undefined { return undefined }
+
+  get isSelected(): boolean {
+    return this.selected
+  }
+
+  deselect() {
+    this.selected = false
+  }
+
+  select() {
+    this.selected = true
+  }
+}
+
+export class KeywordCountPillControl extends AbstractPillControl {
+
+  readonly keywordCount: KeywordCount
+
+  constructor(keywordCount: KeywordCount) {
+    super();
+    this.keywordCount = keywordCount
+  }
+
+  get keyword(): IAlignment | INamedReference | string {
+    return this.keywordCount.keyword
+  }
+
+  get count(): number {
+    return this.keywordCount.count
+  }
+
+  get primaryLabel(): string {
+    return `${this.keyword}`
+  }
+
+  get secondaryLabel(): string | undefined {
+    return `${this.count}`
+  }
+}

--- a/ui/src/app/core/pill/pill.component.html
+++ b/ui/src/app/core/pill/pill.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="hasClickedObservers; then buttonPill; else divPill"></ng-container>
 <ng-template #buttonPill>
-<button class="m-pill" [class.selected]="isSelected"  type="button" (click)="onClick()">
+<button class="m-pill" [class.selected]="isSelected" [tabIndex]="tabSelectEnabled ? 0 : -1"  type="button" (click)="onClick()">
   <div class="m-pill-primary">{{primaryLabel}}</div>
   <div *ngIf="hasSecondaryLabel" class="m-pill-secondary">{{secondaryLabel}}</div>
 </button>

--- a/ui/src/app/core/pill/pill.component.html
+++ b/ui/src/app/core/pill/pill.component.html
@@ -1,0 +1,13 @@
+<ng-container *ngIf="hasClickedObservers; then buttonPill; else divPill"></ng-container>
+<ng-template #buttonPill>
+<button class="m-pill" [class.selected]="isSelected"  type="button" (click)="onClick()">
+  <div class="m-pill-primary">{{primaryLabel}}</div>
+  <div *ngIf="hasSecondaryLabel" class="m-pill-secondary">{{secondaryLabel}}</div>
+</button>
+</ng-template>
+<ng-template #divPill>
+<div class="m-pill" [class.selected]="isSelected">
+  <div class="m-pill-primary">{{primaryLabel}}</div>
+  <div *ngIf="hasSecondaryLabel" class="m-pill-secondary">{{secondaryLabel}}</div>
+</div>
+</ng-template>

--- a/ui/src/app/core/pill/pill.component.spec.ts
+++ b/ui/src/app/core/pill/pill.component.spec.ts
@@ -1,0 +1,104 @@
+// noinspection LocalVariableNamingConventionJS
+import {HttpClientTestingModule} from "@angular/common/http/testing"
+import {Component, Type} from "@angular/core"
+import {async, ComponentFixture, TestBed} from "@angular/core/testing"
+import {FormsModule, ReactiveFormsModule} from "@angular/forms"
+import {ActivatedRoute, Router} from "@angular/router"
+import {RouterTestingModule} from "@angular/router/testing"
+import {AppConfig} from "src/app/app.config"
+import {EnvironmentService} from "src/app/core/environment.service"
+import {ActivatedRouteStubSpec} from "test/util/activated-route-stub.spec"
+import {PillComponent} from "./pill.component";
+import {TestPillControl} from "./pill-control.spec";
+import {AbstractPillControl} from "./pill-control";
+
+@Component({
+  template: "",
+})
+export abstract class TestHostComponent extends PillComponent<AbstractPillControl> {
+  constructor(pillControl: TestPillControl = new TestPillControl()) {
+    super();
+    this.control = pillControl
+  }
+}
+
+let activatedRoute: ActivatedRouteStubSpec
+let fixture: ComponentFixture<TestHostComponent>
+let component: TestHostComponent
+
+function createComponent(T: Type<TestHostComponent>): void {
+  fixture = TestBed.createComponent(T)
+  component = fixture.componentInstance
+  fixture.detectChanges()
+  fixture.whenStable().then(() => fixture.detectChanges())
+}
+
+describe("PillComponent", () => {
+  beforeEach(() => {
+    activatedRoute = new ActivatedRouteStubSpec()
+  })
+
+  beforeEach(async(() => {
+    const routerSpy = ActivatedRouteStubSpec.createRouterSpy()
+
+    TestBed.configureTestingModule({
+      declarations: [
+        PillComponent,
+        TestHostComponent
+      ],
+      imports: [
+        FormsModule,  // Required for ([ngModel])
+        ReactiveFormsModule,
+        RouterTestingModule,  // Required for routerLink
+        HttpClientTestingModule,  // Needed to avoid the toolName race condition below
+      ],
+      providers: [
+        AppConfig,  // Needed to avoid the toolName race condition below
+        EnvironmentService,  // Needed to avoid the toolName race condition below
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: Router, useValue: routerSpy },
+      ]
+    }).compileComponents()
+
+    const appConfig = TestBed.inject(AppConfig)
+    AppConfig.settings = appConfig.defaultConfig()  // This avoids the race condition on reading the config's whitelabel.toolName
+
+    activatedRoute.setParams({ userId: 126 })
+
+    // @ts-ignore
+    createComponent(TestHostComponent)
+  }))
+
+  it("should be created", () => {
+    expect(component).toBeTruthy()
+  })
+
+  it("get isSelelected should return correct result", () => {
+    expect(component.isSelected).toEqual(false)
+    component.control?.select()
+    expect(component.isSelected).toEqual(true)
+  })
+
+  it("get hasClickedObservers should return correct result", () => {
+    expect(component.hasClickedObservers).toEqual(false)
+  })
+
+  it("get hasSecondaryLabel should return correct result", () => {
+    expect(component.hasSecondaryLabel).toEqual(true)
+  })
+
+  it("get primaryLabel should return correct result", () => {
+    expect(component.primaryLabel).toEqual(TestPillControl.TEST_PRIMARY_STRING)
+  })
+
+  it("get secondaryLabel should return correct result", () => {
+    expect(component.secondaryLabel).toEqual(TestPillControl.TEST_SECONDARY_STRING)
+  })
+
+  it("onClick should succeed", () => {
+    expect((() => {
+      component.onClick()
+      return true
+    })()).toEqual(true)
+  })
+})

--- a/ui/src/app/core/pill/pill.component.ts
+++ b/ui/src/app/core/pill/pill.component.ts
@@ -7,6 +7,7 @@ import {AbstractPillControl} from "./pill-control";
 })
 export class PillComponent<TValue extends AbstractPillControl>{
 
+  @Input() tabSelectEnabled: boolean = true
   @Input() control?: TValue = undefined
   @Output() clicked: EventEmitter<TValue> = new EventEmitter()
 
@@ -30,7 +31,7 @@ export class PillComponent<TValue extends AbstractPillControl>{
     return (this.control) ? this.control.secondaryLabel : undefined
   }
 
-  onClick() {
+  onClick(): void {
     this.clicked.emit(this.control)
   }
 }

--- a/ui/src/app/core/pill/pill.component.ts
+++ b/ui/src/app/core/pill/pill.component.ts
@@ -1,0 +1,36 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core"
+import {AbstractPillControl} from "./pill-control";
+
+@Component({
+  selector: "app-pill",
+  templateUrl: "./pill.component.html"
+})
+export class PillComponent<TValue extends AbstractPillControl>{
+
+  @Input() control?: TValue = undefined
+  @Output() clicked: EventEmitter<TValue> = new EventEmitter()
+
+  get isSelected(): boolean {
+    return !!this.control?.isSelected
+  }
+
+  get hasClickedObservers(): boolean {
+    return this.clicked.observers.length > 0
+  }
+
+  get hasSecondaryLabel(): boolean {
+    return !!this.secondaryLabel
+  }
+
+  get primaryLabel(): string {
+    return (this.control) ? this.control.primaryLabel : ''
+  }
+
+  get secondaryLabel(): string | undefined {
+    return (this.control) ? this.control.secondaryLabel : undefined
+  }
+
+  onClick() {
+    this.clicked.emit(this.control)
+  }
+}

--- a/ui/src/app/richskill/ApiSkill.ts
+++ b/ui/src/app/richskill/ApiSkill.ts
@@ -79,6 +79,21 @@ export class ApiAlignment implements IAlignment {
   }
 }
 
+export interface IKeywordCount {
+  keyword: IAlignment|INamedReference|string
+  count: number
+}
+
+export class KeywordCount implements IKeywordCount {
+  keyword: IAlignment|INamedReference|string
+  count: number
+
+  constructor(reference: KeywordCount) {
+    this.keyword = reference.keyword
+    this.count = reference.count
+  }
+}
+
 export enum KeywordType {
   Category = "category",
   Keyword = "keyword",

--- a/ui/src/app/richskill/list/skills-list.component.ts
+++ b/ui/src/app/richskill/list/skills-list.component.ts
@@ -4,9 +4,9 @@ import { Router } from "@angular/router";
 import { Observable } from "rxjs";
 
 import { ApiBatchResult } from "../ApiBatchResult";
-import { ApiSortOrder } from "../ApiSkill";
+import { ApiSortOrder, KeywordType } from "../ApiSkill";
 import { ApiSkillSummary } from "../ApiSkillSummary";
-import { RichSkillService} from "../service/rich-skill.service";
+import { RichSkillService } from "../service/rich-skill.service";
 import { ApiSearch, ApiSkillListUpdate, PaginatedSkills } from "../service/rich-skill-search.service";
 import { ButtonAction } from "../../auth/auth-roles";
 import { AuthService } from "../../auth/auth-service";
@@ -56,6 +56,8 @@ export class SkillsListComponent extends QuickLinksHelper {
   skillsSaved?: Observable<ApiBatchResult>
 
   columnSort: ApiSortOrder = ApiSortOrder.SkillAsc
+
+  showCategories = true
 
   showSearchEmptyMessage = false
   showLibraryEmptyMessage = false

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -39,6 +39,7 @@
 }
 /* [END] Needed for search control refactor until design system is updated */
 
+/* [START] Select style for size-pagination and select-all */
 .select {
   width: fit-content;
   margin-left: 20px;
@@ -53,3 +54,40 @@
   -webkit-appearance: menulist;
   transition: outline var(--t-transition),outline-offset var(--t-transition),border-radius var(--t-transition),border-color var(--t-transition),background-color var(--t-transition),box-shadow var(--t-transition);
 }
+/* [END] Select style for size-pagination and select-all */
+
+/* [START] Pill & Pill Group needed until design system is updated */
+.m-pill-group {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 10px;
+}
+
+.m-pill {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 16px;
+  background-color: var(--color-background100);
+}
+
+.m-pill:disabled {
+  cursor: default;
+}
+
+.m-pill.selected {
+  color: var(--color-text4);
+  background-color: var(--color-interactive1);
+}
+
+.m-pill .m-pill-secondary {
+  margin: 0 0 0 8px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  color: var(--color-text4);
+  background-color: var(--color-background500);
+}
+/* [END] Pill & Pill Group needed until design system is updated */

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -88,7 +88,7 @@
 .m-pill-group-collapsible .read-more-wrapper button {
   width: 100%;
   text-align: center;
-  background-color: var(--color-interactive7);
+  background-color: var(--color-background300);  // 
   color: var(--color-text2);
   border: 1px solid var(--color-text3);
   border-radius: 12px;

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -63,6 +63,41 @@
   gap: 10px;
 }
 
+.m-pill-group-collapsible {
+  max-height: 100000px;
+  position: relative;
+  overflow-y: hidden;
+  transition: max-height 0.5s cubic-bezier(0, 1, 0, 1);
+  padding-bottom: 60px;
+  transition: padding-bottom 0.5s cubic-bezier(0, 1, 0, 1);
+}
+.m-pill-group-collapsible.collapsed {
+  max-height: 100px;
+  padding-bottom: 0;
+  cursor: pointer;
+}
+.m-pill-group-collapsible .read-more-wrapper {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+}
+.m-pill-group-collapsible .read-more-wrapper > div {
+  width: 100px;
+  margin: 1em auto;
+}
+.m-pill-group-collapsible .read-more-wrapper button {
+  width: 100%;
+  text-align: center;
+  background-color: var(--color-interactive7);
+  color: var(--color-text2);
+  border: 1px solid var(--color-text3);
+  border-radius: 12px;
+}
+.m-pill-group-collapsible.collapsed .read-more-wrapper {
+  bottom: 0;
+  background: linear-gradient(rgba(255, 255, 255, 0) 0%, var(--color-background300) 100%);
+}
+
 .m-pill {
   display: flex;
   flex-flow: row nowrap;

--- a/ui/test/resource/mock-data.ts
+++ b/ui/test/resource/mock-data.ts
@@ -11,7 +11,9 @@ import {
   IAuditLog,
   INamedReference,
   ISkill,
-  IUuidReference
+  IUuidReference,
+  KeywordCount,
+  KeywordType
 } from "../../src/app/richskill/ApiSkill"
 import { ApiCollectionSummary, ICollectionSummary, ISkillSummary } from "../../src/app/richskill/ApiSkillSummary"
 import { ApiReferenceListUpdate, IRichSkillUpdate, IStringListUpdate } from "../../src/app/richskill/ApiSkillUpdate"
@@ -253,6 +255,16 @@ export function createMockCollection(
   status: PublishStatus,
   skills: string[] = ["skill 1", "skill 2"]
 ): ICollection {
+  const skillKeywords: Map<KeywordType, KeywordCount[]> = new Map()
+
+  skillKeywords.set(KeywordType.Alignment, [new KeywordCount({ keyword: createMockAlignment(), count: 5 })])
+  skillKeywords.set(KeywordType.Author, [new KeywordCount({ keyword: "author1", count: 2 })])
+  skillKeywords.set(KeywordType.Category, [new KeywordCount({ keyword: "category1", count: 33 })])
+  skillKeywords.set(KeywordType.Certification, [new KeywordCount({ keyword: createMockApiNamedReference(), count: 1 })])
+  skillKeywords.set(KeywordType.Employer, [new KeywordCount({ keyword: createMockNamedReference(), count: 4 })])
+  skillKeywords.set(KeywordType.Keyword, [new KeywordCount({ keyword: "keyword1", count: 111 })])
+  skillKeywords.set(KeywordType.Standard, [new KeywordCount({ keyword: createMockAlignment(), count: 2 })])
+
   return {
     creationDate,
     updateDate,
@@ -264,6 +276,7 @@ export function createMockCollection(
     name: "my collection name",
     author: "name",
     skills,
+    skillKeywords,
     creator: "creator"
   }
 }


### PR DESCRIPTION
resolves https://github.com/wgu-opensource/osmt/issues/300

- Added KeywordCount to store a Keyword and total count.
- Added Map of all KeywordTypes to KeywordCounts that include all keywords and number of Skills with Keyword to Collection.
- Added Pill & PillGroup components to display Categories on Collection pages.
- Added Categories with counts to Collection public & manage pages.
- On Collection manage pages clicking on Category pill filters skills based on Category.