### PR TITLE
Revert GitHub Hosted Runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -21,5 +21,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+    - name: Maven version
+      run: mvn -version
     - name: Build with Maven
       run: mvn -B package


### PR DESCRIPTION
[Available](https://github.com/actions/runner-images) runners images for GitHub Actions.

Seems our project is working with Ubuntu 20.04