### PR TITLE
Add user hint to save new keyword values

### DIFF
--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.html
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.html
@@ -73,6 +73,10 @@
               </span>
                 <span class="m-buttonText-x-text">{{labelFor(r)}}<span class="t-visuallyHidden">, </span></span>
               </button>
+              <!-- Save as new button if not perfect match -->
+              <button class="m-buttonText" type="button" *ngIf="allowSaveNew && !isExactMatchFound()" (click)="selectSearchValue()" [disabled]="false">
+                <span class="m-buttonText-x-icon">Save new: {{ searchControlResultValue }} (Enter)</span>
+              </button>
             </div>
 
             <!-- Empty results -->
@@ -81,6 +85,9 @@
                 <p class="m-selectMenu-x-message">
                   <span class="m-selectMenu-x-messageText">No Results</span>
                 </p>
+                <button class="m-buttonText" type="button" *ngIf="allowSaveNew" (click)="selectSearchValue()" [disabled]="false">
+                  <span class="m-buttonText-x-icon">Save new: {{ searchControlResultValue }} (Enter)</span>
+                </button>
               </div>
             </ng-template>
           </div>

--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.spec.ts
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.spec.ts
@@ -143,4 +143,13 @@ describe("AbstractFormFieldSearchMultiSelectComponent", () => {
       return true
     })()).toEqual(true)
   })
+
+  it("exact match detection works", () => {
+    component.results = []
+    component.searchControlValue = "abc";
+    expect(component.isExactMatchFound()).toEqual(false)
+
+    component.results = [{value:'abc'}]
+    expect(component.isExactMatchFound()).toEqual(true)
+  })
 })

--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.ts
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-multi-select.component.ts
@@ -27,6 +27,11 @@ export abstract class AbstractFormFieldSearchMultiSelect<TValue>
     return false
   }
 
+  isExactMatchFound(): boolean {
+    if (!this.searchControlResultValue) return false
+    return !!(this.results?.find((r: TValue) => this.areSearchResultsEqual(r, this.searchControlResultValue as TValue)))
+  }
+
   selectResult(result: TValue): void {
     if (this.isSearchResultType(result) && !this.isResultSelected(result)){
       let selected: TValue[] = this.controlValue ?? []

--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-select.component.ts
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-select.component.ts
@@ -13,6 +13,7 @@ export abstract class AbstractFormFieldSearchSelect<TSearch, TValue>
   extends AbstractFormField<TValue|null> implements OnInit, OnDestroy {
 
   @Input() createNonExisting = false
+  @Input() allowSaveNew: boolean = false
 
   searchControl: FormControl = new FormControl("")
 
@@ -59,6 +60,11 @@ export abstract class AbstractFormFieldSearchSelect<TSearch, TValue>
     return this.searchControlValue.length <= 0
   }
 
+  isExactMatchFound(): boolean {
+    if (!this.searchControlResultValue) return false
+    return !!(this.results?.find((r: TSearch) => this.areSearchResultsEqual(r, this.searchControlResultValue as TSearch)))
+  }
+
   get searchControlValue(): string {
     return this.searchControl.value?.trim() ?? ""
   }
@@ -73,7 +79,7 @@ export abstract class AbstractFormFieldSearchSelect<TSearch, TValue>
     const searchResult = this.searchResultFromString(this.searchControlValue)
 
     if (searchResult) {
-      const existingResult =this.results?.find((r: TSearch) => this.areSearchResultsEqual(r, searchResult))
+      const existingResult = this.results?.find((r: TSearch) => this.areSearchResultsEqual(r, searchResult))
       return existingResult ?? (this.createNonExisting) ? searchResult : undefined
     }
 

--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-single-select.component.html
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-single-select.component.html
@@ -57,6 +57,9 @@
               <button class="m-buttonText" *ngFor="let r of results" type="button" (click)="onSearchResultClicked(r)">
                 <span class="m-buttonText-x-text">{{labelFor(r)}}</span>
               </button>
+              <button class="m-buttonText" type="button" *ngIf="allowSaveNew && !isExactMatchFound()" (click)="selectSearchValue()" [disabled]="false">
+                <span class="m-buttonText-x-icon">Save new: {{ searchControlResultValue }} (Enter)</span>
+              </button>
             </div>
 
             <!-- Empty results -->
@@ -65,6 +68,9 @@
                 <p class="m-selectMenu-x-message">
                   <span class="m-selectMenu-x-messageText">No Results</span>
                 </p>
+                <button class="m-buttonText" type="button" *ngIf="allowSaveNew" (click)="selectSearchValue()" [disabled]="false">
+                  <span class="m-buttonText-x-icon">Save new: {{ searchControlResultValue }} (Enter)</span>
+                </button>
               </div>
             </ng-template>
           </div>

--- a/ui/src/app/form/form-field-search-select/abstract-form-field-search-single-select.component.spec.ts
+++ b/ui/src/app/form/form-field-search-select/abstract-form-field-search-single-select.component.spec.ts
@@ -129,4 +129,13 @@ describe("AbstractFormFieldSearchSingleSelectComponent", () => {
       return true
     })()).toEqual(true)
   })
+
+  it("exact match detection works", () => {
+    component.results = []
+    component.searchControlValue = "abc";
+    expect(component.isExactMatchFound()).toEqual(false)
+
+    component.results = [{value:'abc'}]
+    expect(component.isExactMatchFound()).toEqual(true)
+  })
 })

--- a/ui/src/app/richskill/form/rich-skill-form.component.html
+++ b/ui/src/app/richskill/form/rich-skill-form.component.html
@@ -42,6 +42,7 @@
                 [errorMessage]="authorErrorMessage"
                 [keywordType]="keywordType.Author"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 
@@ -74,6 +75,7 @@
                 helpMessage="Industry-recognized, general terms that represents a broad group of related RSDs."
                 [keywordType]="keywordType.Category"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 
@@ -87,6 +89,7 @@
                 errorMessage="Keywords are required"
                 [keywordType]="keywordType.Keyword"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 
@@ -99,6 +102,7 @@
                 helpMessage="Names of professional standards that define skill mastery, sourced from industry-recognized frameworks."
                 [keywordType]="keywordType.Standard"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 
@@ -111,6 +115,7 @@
                 helpMessage="Related academic and professional certifications that support career advancement."
                 [keywordType]="keywordType.Certification"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 
@@ -133,6 +138,7 @@
                 helpMessage="Employers who require this skill for a given job. Employers are not visible in the public view of an RSD."
                 [keywordType]="keywordType.Employer"
                 [createNonExisting]="true"
+                [allowSaveNew]="true"
               ></app-form-field-keyword-search-multi-select>
             </div>
 


### PR DESCRIPTION
Closes #112

I rejected the suggested approach to just change the gray text, because would go against UX patterns. The text is supposed to suggest a possible value that might be entered, rather than provide instruction. But the underlying issue was correct: the user didn't know that they could create a new keyword by hitting Enter. 

Now, when relevant, a new button appears in the search result list. When a user selects it (or hits their "Enter" key while the input control is selected, the current search value is set to be saved as a new keyword value. This button appears when:
* A search term has been entered, but no corresponding result is found
* A search term has been entered, and some results have been returned, but none of the results exactly matches the search term.

It does not appear when:
* a search term has been entered that is an exact match of a found result.

![Screenshot_2023-04-27_at_12_01_29_PM](https://user-images.githubusercontent.com/2304883/234965655-f40231de-cf0d-4aee-9aee-9a2e2631f799.png)