### PR TITLE
Add missing action bar to rich-skill-form-component

### DIFF
--- a/ui/src/app/richskill/form/rich-skill-form.component.html
+++ b/ui/src/app/richskill/form/rich-skill-form.component.html
@@ -264,8 +264,30 @@
 
       </div>
 
-      <div class="l-stickyBar-x-bar t-hidden-desktopMin t-padding-medium t-padding-top">
+      <div class="l-stickyBar-x-bar t-hidden-desktopMin">
         <!-- @actionbarhorizontal -->
+        <nav class="l-flex l-flex-alignCenter l-flex-0 t-elevation-large">
+          <button class="m-actionBarItemHorizontal m-actionBarItemHorizontal-secondary" type="button" (click)="handleClickCancel()">
+            <svg class="m-actionBarItemHorizontal-x-icon t-icon">
+              <use [attr.xlink:href]="cancelIcon"></use>
+            </svg>
+            <span class="m-actionBarItemHorizontal-x-label">Cancel</span>
+            <span class="m-actionBarItemHorizontal-x-divider m-divider m-divider-large"></span>
+          </button>
+    
+          <app-formfield-submit
+                [formGroup]="skillForm"
+                [enabled]="formValid"
+                [dirty]="formDirty"
+                [observables]="[skillSaved]"
+                [mobileView]="true"
+                (errorsOccurred)="handleFormErrors($event)"
+              ></app-formfield-submit>
+          <div class="m-quickLinks" aria-labelledby="save-quicklinks">
+            <h3 class="t-visuallyHidden" id="save-quicklinks">Quick Links</h3>
+            <a (click)="scrollToTopClicked.emit()">Back to top</a>
+          </div>
+        </nav>
       </div>
     </div>
 

--- a/ui/src/app/richskill/form/rich-skill-form.component.ts
+++ b/ui/src/app/richskill/form/rich-skill-form.component.ts
@@ -28,6 +28,7 @@ import {HasFormGroup} from "../../core/abstract-form.component"
 import {notACopyValidator} from "../../validators/not-a-copy.validator"
 import {ApiSkillSummary} from "../ApiSkillSummary"
 import {Whitelabelled} from "../../../whitelabel"
+import { SvgHelper, SvgIcon } from "src/app/core/SvgHelper"
 
 @Component({
   selector: "app-rich-skill-form",
@@ -49,6 +50,9 @@ export class RichSkillFormComponent extends Whitelabelled implements OnInit, Has
   // for skill statement similarity checking
   searchingSimilarity?: boolean
   similarSkills?: ApiSkillSummary[]
+
+  iconCollection = SvgHelper.path(SvgIcon.COLLECTION)
+  cancelIcon = SvgHelper.path(SvgIcon.CANCEL)
 
   constructor(
     private fb: FormBuilder,


### PR DESCRIPTION
Closes #382

Now the action bar appears in the skill view. It looked like the code had just been removed from the template or had never been added. There was a spot for it. Some more significant cleanup of the action bar components would be worthwhile. The ones created for collections weren't created to be very reusable.

![Screenshot 2023-04-27 at 2 14 16 PM](https://user-images.githubusercontent.com/2304883/234992698-fe990185-c7a5-4337-ba51-e309ba515567.png)
