### PR TITLE
Lengthens default session length to avoid constant logout experience

### DIFF
--- a/ui/src/app/app.config.spec.ts
+++ b/ui/src/app/app.config.spec.ts
@@ -53,6 +53,7 @@ describe("AppConfig", () => {
 
       settingsService.load().finally(() => {
         expect(AppConfig.settings.baseApiUrl).toBe(dummyConfig.baseApiUrl)
+        expect(AppConfig.settings.idleTimeoutInSeconds).toBe(86400)  // loaded from app.config.ts
       })
 
     })

--- a/ui/src/app/models/app-config.model.ts
+++ b/ui/src/app/models/app-config.model.ts
@@ -31,7 +31,7 @@ export class DefaultAppConfig implements IAppConfig {
   poweredBy = "Powered by the"
   poweredByUrl = "https://rsd.osmt.dev"
   poweredByLabel = "Open Skills Network"
-  idleTimeoutInSeconds = 15 * 60
+  idleTimeoutInSeconds = 24 * 60 * 60
   colorBrandAccent1 = undefined
   dynamicWhitelabel = false
 }


### PR DESCRIPTION
Closes #205 with a proposed default session idle timeout of 24 hours instead of 15 minutes. 