### PR TITLE
Fix select page in collection skill search

### DIFF
--- a/ui/src/app/collection/collection-skill-search.component.spec.ts
+++ b/ui/src/app/collection/collection-skill-search.component.spec.ts
@@ -191,7 +191,7 @@ describe("CollectionSkillSearchComponent", () => {
 
   it("getApiSearch should return canned search", () => {
     // Arrange
-    component.multiplePagesSelected = true
+    component.selectAllChecked = true
     const search = "testQueryString"
     component.searchForm.setValue({search})
 
@@ -204,14 +204,12 @@ describe("CollectionSkillSearchComponent", () => {
 
   it("getApiSearch should return specified search", () => {
     // Arrange
-    component.multiplePagesSelected = false
-    const skill = createMockSkillSummary()
-
-    // Act
-    const result = component.getApiSearch(skill)
+    component.selectAllChecked = false
+    component.selectedSkills = [createMockSkillSummary("1")]
+    const result = component.selectedUuids()
 
     // Assert
-    expect(result).toEqual(new ApiSearch({ uuids: [ skill.uuid ] } ))
+    expect(result).toEqual(component.getApiSearch()?.uuids)
   })
 
   it("handleSelectAll should be correct", () => {
@@ -222,7 +220,7 @@ describe("CollectionSkillSearchComponent", () => {
     // Act
     component.handleSelectAll(true)
     // Assert
-    expect(component.multiplePagesSelected).toBeTrue()
+    expect(component.selectAllChecked).toBeTrue()
 
     // Arrange
     component.results = new PaginatedSkills([], 5)

--- a/ui/src/app/collection/collection-skill-search.component.ts
+++ b/ui/src/app/collection/collection-skill-search.component.ts
@@ -125,7 +125,7 @@ export class CollectionSkillSearchComponent extends SkillsListComponent implemen
       if (result) {
         this.toastService.hideBlockingLoader()
         const isWorkspace = this.collection?.status === PublishStatus.Workspace
-        const baseMessage = `You added ${selectedCount} RSD${selectedCount ? "s" : ""} to the`
+        const baseMessage = `You added ${this.selectAllChecked ? this.totalCount : this.size} RSD${selectedCount ? "s" : ""} to the`
         const message = ` ${baseMessage} ${this.collectionOrWorkspace(false)} ${ isWorkspace ? "" : this.collection?.name}.`
         this.toastService.showToast("Success!", message)
       }
@@ -135,10 +135,7 @@ export class CollectionSkillSearchComponent extends SkillsListComponent implemen
   }
 
   getApiSearch(skill?: ApiSkillSummary): ApiSearch | undefined {
-    return (this.multiplePagesSelected) ? new ApiSearch({query: this.searchQuery}) : super.getApiSearch(skill)
+    return this.selectAllChecked ? new ApiSearch({query: this.searchQuery}) : new ApiSearch({uuids: this.selectedUuids()})
   }
 
-  handleSelectAll(selectAllChecked: boolean): void {
-    this.multiplePagesSelected = this.totalPageCount > 1
-  }
 }


### PR DESCRIPTION
To reproduce this in local
1. Go to any collection
2. Click on "Add RSDs to This Collection"
3. Do a search (we need more results than the size of the pagination)
4. Try to add only all in the current page
