### PR TITLE
Back end endpoints for MetaData

### DIFF
--- a/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
@@ -66,6 +66,13 @@ object RoutePaths {
     const val JOB_CODE_UPDATE = JOB_CODE_DETAIL
     const val JOB_CODE_REMOVE = JOB_CODE_DETAIL
 
+    const val NAMED_REFERENCES_PATH = "$METADATA_PATH/named-references"
+    const val NAMED_REFERENCES_CREATE = NAMED_REFERENCES_PATH
+    const val NAMED_REFERENCES_LIST = NAMED_REFERENCES_PATH
+    const val NAMED_REFERENCES_DETAIL = "$NAMED_REFERENCES_PATH/{id}"
+    const val NAMED_REFERENCES_UPDATE = NAMED_REFERENCES_DETAIL
+    const val NAMED_REFERENCES_REMOVE = NAMED_REFERENCES_DETAIL
+
     object QueryParams {
         const val FROM = "from"
         const val SIZE = "size"

--- a/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
@@ -62,9 +62,9 @@ object RoutePaths {
     const val JOB_CODE_PATH = "$METADATA_PATH/job-codes"
     const val JOB_CODE_CREATE = JOB_CODE_PATH
     const val JOB_CODE_LIST = JOB_CODE_PATH
-    const val JOB_CODE_DETAIL = "$JOB_CODE_PATH/{uuid}"
-    const val JOB_CODE_UPDATE = "$JOB_CODE_DETAIL/update"
-    const val JOB_CODE_REMOVE = "$JOB_CODE_DETAIL/remove"
+    const val JOB_CODE_DETAIL = "$JOB_CODE_PATH/{id}"
+    const val JOB_CODE_UPDATE = JOB_CODE_DETAIL
+    const val JOB_CODE_REMOVE = JOB_CODE_DETAIL
 
     object QueryParams {
         const val FROM = "from"

--- a/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
@@ -58,6 +58,14 @@ object RoutePaths {
     const val ES_ADMIN_DELETE_INDICES = "$ES_ADMIN/delete-indices"
     const val ES_ADMIN_REINDEX = "$ES_ADMIN/reindex"
 
+    const val METADATA_PATH = "$API/metadata"
+    const val JOB_CODE_PATH = "$METADATA_PATH/job-codes"
+    const val JOB_CODE_CREATE = JOB_CODE_PATH
+    const val JOB_CODE_LIST = JOB_CODE_PATH
+    const val JOB_CODE_DETAIL = "$JOB_CODE_PATH/{uuid}"
+    const val JOB_CODE_UPDATE = "$JOB_CODE_DETAIL/update"
+    const val JOB_CODE_REMOVE = "$JOB_CODE_DETAIL/remove"
+
     object QueryParams {
         const val FROM = "from"
         const val SIZE = "size"

--- a/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/RoutePaths.kt
@@ -59,19 +59,19 @@ object RoutePaths {
     const val ES_ADMIN_REINDEX = "$ES_ADMIN/reindex"
 
     const val METADATA_PATH = "$API/metadata"
-    const val JOB_CODE_PATH = "$METADATA_PATH/job-codes"
+    const val JOB_CODE_PATH = "$METADATA_PATH/jobcodes"
     const val JOB_CODE_CREATE = JOB_CODE_PATH
     const val JOB_CODE_LIST = JOB_CODE_PATH
     const val JOB_CODE_DETAIL = "$JOB_CODE_PATH/{id}"
-    const val JOB_CODE_UPDATE = JOB_CODE_DETAIL
-    const val JOB_CODE_REMOVE = JOB_CODE_DETAIL
+    const val JOB_CODE_UPDATE = "$JOB_CODE_DETAIL/update"
+    const val JOB_CODE_REMOVE = "$JOB_CODE_DETAIL/remove"
 
     const val NAMED_REFERENCES_PATH = "$METADATA_PATH/named-references"
     const val NAMED_REFERENCES_CREATE = NAMED_REFERENCES_PATH
     const val NAMED_REFERENCES_LIST = NAMED_REFERENCES_PATH
     const val NAMED_REFERENCES_DETAIL = "$NAMED_REFERENCES_PATH/{id}"
-    const val NAMED_REFERENCES_UPDATE = NAMED_REFERENCES_DETAIL
-    const val NAMED_REFERENCES_REMOVE = NAMED_REFERENCES_DETAIL
+    const val NAMED_REFERENCES_UPDATE = "$NAMED_REFERENCES_DETAIL/update"
+    const val NAMED_REFERENCES_REMOVE = "$NAMED_REFERENCES_DETAIL/remove"
 
     object QueryParams {
         const val FROM = "from"

--- a/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
@@ -1,0 +1,17 @@
+package edu.wgu.osmt.api.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class JobCodeUpdate(
+    @JsonProperty("code")
+    val code: String = "",
+    @JsonProperty("frameworkName")
+    val framework: String = "",
+    @JsonProperty("targetNodeName")
+    val targetNodeName: String = "",
+    @JsonProperty("level")
+    val level: String = "",
+    @JsonProperty("description")
+    val description: String = ""
+) {
+}

--- a/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
@@ -16,7 +16,5 @@ data class JobCodeUpdate(
     val level: JobCodeLevel? = null,
     @JsonProperty("parents")
     val parents: List<JobCodeUpdate>? = null
-    // @JsonProperty("description")
-    // val description: String = ""
 ) {
 }

--- a/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/api/model/JobCodeUpdate.kt
@@ -1,17 +1,22 @@
 package edu.wgu.osmt.api.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import edu.wgu.osmt.db.JobCodeLevel
 
 data class JobCodeUpdate(
     @JsonProperty("code")
-    val code: String = "",
-    @JsonProperty("frameworkName")
-    val framework: String = "",
+    val code: String,
+    @JsonProperty("targetNode")
+    val targetNode: String? = null,
     @JsonProperty("targetNodeName")
-    val targetNodeName: String = "",
+    val targetNodeName: String? = null,
+    @JsonProperty("frameworkName")
+    val framework: String? = null,
     @JsonProperty("level")
-    val level: String = "",
-    @JsonProperty("description")
-    val description: String = ""
+    val level: JobCodeLevel? = null,
+    @JsonProperty("parents")
+    val parents: List<JobCodeUpdate>? = null
+    // @JsonProperty("description")
+    // val description: String = ""
 ) {
 }

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
@@ -8,6 +8,7 @@ import edu.wgu.osmt.task.TaskResult
 import edu.wgu.osmt.task.TaskStatus
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.server.ResponseStatusException
 
 @Controller
 @Transactional
@@ -40,7 +42,7 @@ class JobCodeController @Autowired constructor(
 
     @GetMapping(RoutePaths.JOB_CODE_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
-    fun byUuid(
+    fun byId(
         @PathVariable id: Int,
     ): HttpEntity<ApiJobCode> {
         val jobCode = jobCodeEsRepo.findById(id)

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
@@ -1,0 +1,79 @@
+package edu.wgu.osmt.jobcode;
+
+import edu.wgu.osmt.PaginationDefaults
+import edu.wgu.osmt.RoutePaths
+import edu.wgu.osmt.api.model.ApiJobCode
+import edu.wgu.osmt.api.model.JobCodeUpdate
+import edu.wgu.osmt.collection.CollectionDao
+import edu.wgu.osmt.config.AppConfig
+import edu.wgu.osmt.elasticsearch.OffsetPageable
+import edu.wgu.osmt.task.TaskResult
+import edu.wgu.osmt.task.TaskStatus
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.annotation.Secured
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*
+import java.util.*
+import javax.annotation.security.RolesAllowed
+
+@Controller
+@Transactional
+class JobCodeController @Autowired constructor(
+    val jobCodeEsRepo: JobCodeEsRepo,
+    val jobCodeRepository: JobCodeRepository,
+    val appConfig: AppConfig
+) {
+
+    val dao = JobCodeDao.Companion
+
+    @GetMapping(RoutePaths.JOB_CODE_LIST, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasRole('Osmt_Admin') or hasRole('Osmt_Curator')")
+    fun allPaginated(
+        @RequestParam query: String,
+        @RequestParam(required = false, defaultValue = PaginationDefaults.size.toString()) size: Int,
+        @RequestParam(required = false, defaultValue = "0") from: Int,
+    ): HttpEntity<List<ApiJobCode>> {
+        val searchResults = jobCodeEsRepo.typeAheadSearch(query, OffsetPageable(from, size, null))
+        return ResponseEntity.status(200).body(searchResults.map { ApiJobCode.fromJobCode(it.content) }.toList())
+    }
+
+    @GetMapping(RoutePaths.JOB_CODE_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasRole('Osmt_Admin') or hasRole('Osmt_Curator')")
+    fun byUuid(
+        @PathVariable id: Int,
+    ): HttpEntity<ApiJobCode> {
+        val jobCode = jobCodeEsRepo.findById(id)
+        return ResponseEntity.status(200).body(ApiJobCode.fromJobCode(jobCode.get()))
+    }
+
+    @PostMapping(RoutePaths.JOB_CODE_CREATE, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasRole('Osmt_Admin')")
+    fun createJobCode(
+        @RequestBody jobCodeUpdate: JobCodeUpdate
+    ): HttpEntity<ApiJobCode> {
+        val newJobCode = jobCodeRepository.create("20-300", "vn")
+        return ResponseEntity.status(200).body(ApiJobCode.fromJobCode(newJobCode.toModel()))
+    }
+
+    @PutMapping(RoutePaths.JOB_CODE_UPDATE, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasRole('Osmt_Admin')")
+    fun updateJobCode(
+        @PathVariable id: Int,
+    ): HttpEntity<ApiJobCode> {
+        return ResponseEntity.status(200).body(ApiJobCode(code = "1", targetNode = "target", targetNodeName = "targetNodeName", frameworkName = "frameworkName"))
+    }
+
+    @DeleteMapping(RoutePaths.JOB_CODE_REMOVE)
+    @PreAuthorize("hasRole('Osmt_Admin')")
+    fun deleteJobCode(
+        @PathVariable id: Int,
+    ): HttpEntity<TaskResult> {
+        return ResponseEntity.status(200).body(TaskResult(uuid = "uuid", contentType = "json", status = TaskStatus.Processing, apiResultPath = "path"))
+    }
+
+}

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
@@ -43,10 +43,14 @@ class JobCodeController @Autowired constructor(
     @GetMapping(RoutePaths.JOB_CODE_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
     fun byId(
-        @PathVariable id: Int,
+        @PathVariable id: Long,
     ): HttpEntity<ApiJobCode> {
-        val jobCode = jobCodeEsRepo.findById(id)
-        return ResponseEntity.status(200).body(ApiJobCode.fromJobCode(jobCode.get()))
+        val jobCode = jobCodeRepository.findById(id)
+        if (jobCode != null) {
+            return ResponseEntity.status(200).body(ApiJobCode.fromJobCode(jobCode.toModel()))
+        } else {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        }
     }
 
     @PostMapping(RoutePaths.JOB_CODE_CREATE, produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeController.kt
@@ -13,8 +13,12 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.bind.annotation.*
-import java.util.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 @Controller
 @Transactional

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
@@ -59,10 +59,11 @@ class JobCodeRepositoryImpl: JobCodeRepository {
             this.code = jobCodeUpdate.code
             this.framework = jobCodeUpdate.framework
             this.name = jobCodeUpdate.targetNodeName
+            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
             this.description = jobCodeUpdate.description
             this.name = "my name"
             this.major = "my major"
-        }
+        }.also { jobCodeEsRepo.save(it.toModel()) }
     }
 
     override fun findByCodeOrCreate(code: String, framework: String?): JobCodeDao {

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
@@ -1,5 +1,6 @@
 package edu.wgu.osmt.jobcode
 
+import edu.wgu.osmt.api.model.JobCodeUpdate
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.and
@@ -19,6 +20,7 @@ interface JobCodeRepository {
     fun findByCodeOrCreate(code: String, framework: String? = null): JobCodeDao
     fun findBlsCode(code: String): JobCodeDao?
     fun create(code: String, framework: String? = null): JobCodeDao
+    fun createFromApi(jobCodeUpdate: JobCodeUpdate): JobCodeDao
     fun onetsByDetailCode(detailedCode: String): SizedIterable<JobCodeDao>
 
     companion object {
@@ -50,6 +52,17 @@ class JobCodeRepositoryImpl: JobCodeRepository {
     override fun findBlsCode(code: String): JobCodeDao? {
         return table.select { table.code eq code and (table.framework eq JobCodeRepository.BLS_FRAMEWORK) }
             .firstOrNull()?.let { dao.wrapRow(it) }
+    }
+
+    override fun createFromApi(jobCodeUpdate: JobCodeUpdate): JobCodeDao {
+        return dao.new {
+            this.code = jobCodeUpdate.code
+            this.framework = jobCodeUpdate.framework
+            this.name = jobCodeUpdate.targetNodeName
+            this.description = jobCodeUpdate.description
+            this.name = "my name"
+            this.major = "my major"
+        }
     }
 
     override fun findByCodeOrCreate(code: String, framework: String?): JobCodeDao {

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
@@ -61,7 +61,6 @@ class JobCodeRepositoryImpl: JobCodeRepository {
                 this.framework = jobCodeUpdate.framework
                 this.name = jobCodeUpdate.targetNodeName
                 this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
-                // this.description = jobCodeUpdate.description
                 this.name = "my name"
                 this.major = "my major"
             }.also { jobCodeEsRepo.save(it.toModel()) }

--- a/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/jobcode/JobCodeRepository.kt
@@ -20,7 +20,7 @@ interface JobCodeRepository {
     fun findByCodeOrCreate(code: String, framework: String? = null): JobCodeDao
     fun findBlsCode(code: String): JobCodeDao?
     fun create(code: String, framework: String? = null): JobCodeDao
-    fun createFromApi(jobCodeUpdate: JobCodeUpdate): JobCodeDao
+    fun createFromApi(jobCodes: List<JobCodeUpdate>): List<JobCodeDao>
     fun onetsByDetailCode(detailedCode: String): SizedIterable<JobCodeDao>
 
     companion object {
@@ -54,16 +54,18 @@ class JobCodeRepositoryImpl: JobCodeRepository {
             .firstOrNull()?.let { dao.wrapRow(it) }
     }
 
-    override fun createFromApi(jobCodeUpdate: JobCodeUpdate): JobCodeDao {
-        return dao.new {
-            this.code = jobCodeUpdate.code
-            this.framework = jobCodeUpdate.framework
-            this.name = jobCodeUpdate.targetNodeName
-            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
-            this.description = jobCodeUpdate.description
-            this.name = "my name"
-            this.major = "my major"
-        }.also { jobCodeEsRepo.save(it.toModel()) }
+    override fun createFromApi(jobCodes: List<JobCodeUpdate>): List<JobCodeDao> {
+        return jobCodes.map { jobCodeUpdate ->
+            dao.new {
+                this.code = jobCodeUpdate.code
+                this.framework = jobCodeUpdate.framework
+                this.name = jobCodeUpdate.targetNodeName
+                this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
+                // this.description = jobCodeUpdate.description
+                this.name = "my name"
+                this.major = "my major"
+            }.also { jobCodeEsRepo.save(it.toModel()) }
+        }
     }
 
     override fun findByCodeOrCreate(code: String, framework: String?): JobCodeDao {

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
@@ -1,0 +1,19 @@
+package edu.wgu.osmt.keyword
+
+import edu.wgu.osmt.api.model.ApiNamedReference
+
+data class ApiKeyword(
+    val id: Long?,
+    val name: String?,
+    val value: String?,
+    val type: KeywordTypeEnum,
+    val framework: String?
+) {
+
+    companion object factory {
+        fun fromKeyword(keyword: Keyword): ApiKeyword {
+            return ApiKeyword(keyword.id, keyword.value, keyword.value, keyword.type, keyword.framework)
+        }
+    }
+
+}

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
@@ -1,6 +1,18 @@
 package edu.wgu.osmt.keyword
 
-import edu.wgu.osmt.api.model.ApiNamedReference
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ApiKeywordUpdate(
+    @JsonProperty("name")
+    val name: String?,
+    @JsonProperty("value")
+    val value: String?,
+    @JsonProperty("type")
+    val type: KeywordTypeEnum,
+    @JsonProperty("framework")
+    val framework: String?
+) {
+}
 
 data class ApiKeyword(
     val id: Long?,

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/ApiKeyword.kt
@@ -14,7 +14,7 @@ data class ApiKeywordUpdate(
 ) {
 }
 
-data class ApiKeyword(
+data class NamedReference(
     val id: Long?,
     val name: String?,
     val value: String?,
@@ -23,8 +23,8 @@ data class ApiKeyword(
 ) {
 
     companion object factory {
-        fun fromKeyword(keyword: Keyword): ApiKeyword {
-            return ApiKeyword(keyword.id, keyword.value, keyword.value, keyword.type, keyword.framework)
+        fun fromKeyword(keyword: Keyword): NamedReference {
+            return NamedReference(keyword.id, keyword.value, keyword.value, keyword.type, keyword.framework)
         }
     }
 

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -2,10 +2,6 @@ package edu.wgu.osmt.keyword
 
 import edu.wgu.osmt.PaginationDefaults
 import edu.wgu.osmt.RoutePaths
-import edu.wgu.osmt.api.GeneralApiException
-import edu.wgu.osmt.api.model.ApiJobCode
-import edu.wgu.osmt.api.model.ApiNamedReference
-import edu.wgu.osmt.api.model.JobCodeUpdate
 import edu.wgu.osmt.task.TaskResult
 import edu.wgu.osmt.task.TaskStatus
 import org.springframework.beans.factory.annotation.Autowired
@@ -16,7 +12,12 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
 
 @Controller

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -2,6 +2,7 @@ package edu.wgu.osmt.keyword
 
 import edu.wgu.osmt.PaginationDefaults
 import edu.wgu.osmt.RoutePaths
+import edu.wgu.osmt.api.model.ApiJobCode
 import edu.wgu.osmt.task.TaskResult
 import edu.wgu.osmt.task.TaskStatus
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,10 +44,14 @@ class NamedReferencesController @Autowired constructor(
     @GetMapping(RoutePaths.NAMED_REFERENCES_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
     fun byId(
-        @PathVariable id: Int,
+        @PathVariable id: Long,
     ): HttpEntity<ApiKeyword> {
-        val keyword = keywordEsRepo.findById(id)
-        return ResponseEntity.status(200).body(ApiKeyword.fromKeyword(keyword.get()))
+        val keyword = keywordRepository.findById(id)
+        if (keyword != null) {
+            return ResponseEntity.status(200).body(ApiKeyword.fromKeyword(keyword.toModel()))
+        } else {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        }
     }
 
     @PostMapping(RoutePaths.NAMED_REFERENCES_CREATE, produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -2,7 +2,6 @@ package edu.wgu.osmt.keyword
 
 import edu.wgu.osmt.PaginationDefaults
 import edu.wgu.osmt.RoutePaths
-import edu.wgu.osmt.api.model.ApiJobCode
 import edu.wgu.osmt.task.TaskResult
 import edu.wgu.osmt.task.TaskStatus
 import org.springframework.beans.factory.annotation.Autowired

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -33,6 +33,7 @@ class NamedReferencesController @Autowired constructor(
         @RequestParam(required = true) type: String,
         @RequestParam(required = false, defaultValue = PaginationDefaults.size.toString()) size: Int,
         @RequestParam(required = false, defaultValue = "0") from: Int,
+        @RequestParam(required = false) sort: String?
     ): HttpEntity<List<ApiKeyword>> {
         val keywordType = KeywordTypeEnum.forApiValue(type) ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         val searchResults = keywordEsRepo.typeAheadSearch("", keywordType)
@@ -41,7 +42,7 @@ class NamedReferencesController @Autowired constructor(
 
     @GetMapping(RoutePaths.NAMED_REFERENCES_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
-    fun byUuid(
+    fun byId(
         @PathVariable id: Int,
     ): HttpEntity<ApiKeyword> {
         val keyword = keywordEsRepo.findById(id)

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -1,0 +1,75 @@
+package edu.wgu.osmt.keyword
+
+import edu.wgu.osmt.PaginationDefaults
+import edu.wgu.osmt.RoutePaths
+import edu.wgu.osmt.api.model.ApiJobCode
+import edu.wgu.osmt.api.model.ApiNamedReference
+import edu.wgu.osmt.api.model.JobCodeUpdate
+import edu.wgu.osmt.task.TaskResult
+import edu.wgu.osmt.task.TaskStatus
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+
+@Controller
+@Transactional
+class NamedReferencesController @Autowired constructor(
+    val keywordEsRepo: KeywordEsRepo,
+    val keywordRepository: KeywordRepository
+) {
+
+    @GetMapping(RoutePaths.NAMED_REFERENCES_LIST, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("isAuthenticated()")
+    fun allPaginated(
+        @RequestParam query: String,
+        @RequestParam(required = false, defaultValue = PaginationDefaults.size.toString()) size: Int,
+        @RequestParam(required = false, defaultValue = "0") from: Int,
+        @RequestParam(required = true) type: String
+    ): HttpEntity<List<ApiKeyword>> {
+        val keywordType = KeywordTypeEnum.forApiValue(type) ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+        val searchResults = keywordEsRepo.typeAheadSearch(query, keywordType)
+        return ResponseEntity.status(200).body(searchResults.map { ApiKeyword.fromKeyword(it.content) }.toList())
+    }
+
+    @GetMapping(RoutePaths.NAMED_REFERENCES_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("isAuthenticated()")
+    fun byUuid(
+        @PathVariable id: Int,
+    ): HttpEntity<ApiKeyword> {
+        val keyword = keywordEsRepo.findById(id)
+        return ResponseEntity.status(200).body(ApiKeyword.fromKeyword(keyword.get()))
+    }
+
+    @PostMapping(RoutePaths.JOB_CODE_CREATE, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasAuthority(@appConfig.roleAdmin)")
+    fun createNamedReference(
+        @RequestBody apiKeyword: ApiKeyword
+    ): HttpEntity<ApiKeyword> {
+        return ResponseEntity.status(200).body(ApiKeyword(2, "my keyword", "my value", KeywordTypeEnum.Keyword, "my framework"))
+    }
+
+    @PutMapping(RoutePaths.NAMED_REFERENCES_UPDATE, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PreAuthorize("hasAuthority(appConfig.roleAdmin)")
+    fun updateNamedReference(
+        @PathVariable id: Int,
+        @RequestBody apiKeyword: ApiKeyword
+    ): HttpEntity<ApiKeyword> {
+        return ResponseEntity.status(200).body(ApiKeyword(134, "my name", "my value", KeywordTypeEnum.Keyword, "my framework"))
+    }
+
+    @DeleteMapping(RoutePaths.NAMED_REFERENCES_REMOVE)
+    @PreAuthorize("hasAuthority(appConfig.roleAdmin)")
+    fun deleteNamedReference(
+        @PathVariable id: Int,
+    ): HttpEntity<TaskResult> {
+        return ResponseEntity.status(200).body(TaskResult(uuid = "uuid", contentType = "json", status = TaskStatus.Processing, apiResultPath = "path"))
+    }
+
+}

--- a/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/keyword/NamedReferencesController.kt
@@ -34,20 +34,20 @@ class NamedReferencesController @Autowired constructor(
         @RequestParam(required = false, defaultValue = PaginationDefaults.size.toString()) size: Int,
         @RequestParam(required = false, defaultValue = "0") from: Int,
         @RequestParam(required = false) sort: String?
-    ): HttpEntity<List<ApiKeyword>> {
+    ): HttpEntity<List<NamedReference>> {
         val keywordType = KeywordTypeEnum.forApiValue(type) ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         val searchResults = keywordEsRepo.typeAheadSearch("", keywordType)
-        return ResponseEntity.status(200).body(searchResults.map { ApiKeyword.fromKeyword(it.content) }.toList())
+        return ResponseEntity.status(200).body(searchResults.map { NamedReference.fromKeyword(it.content) }.toList())
     }
 
     @GetMapping(RoutePaths.NAMED_REFERENCES_DETAIL, produces = [MediaType.APPLICATION_JSON_VALUE])
     @PreAuthorize("isAuthenticated()")
     fun byId(
         @PathVariable id: Long,
-    ): HttpEntity<ApiKeyword> {
+    ): HttpEntity<NamedReference> {
         val keyword = keywordRepository.findById(id)
         if (keyword != null) {
-            return ResponseEntity.status(200).body(ApiKeyword.fromKeyword(keyword.toModel()))
+            return ResponseEntity.status(200).body(NamedReference.fromKeyword(keyword.toModel()))
         } else {
             throw ResponseStatusException(HttpStatus.NOT_FOUND)
         }
@@ -57,10 +57,10 @@ class NamedReferencesController @Autowired constructor(
     @PreAuthorize("hasAuthority(@appConfig.roleAdmin)")
     fun createNamedReference(
         @RequestBody keywords: List<ApiKeywordUpdate>
-    ): HttpEntity<List<ApiKeyword>> {
+    ): HttpEntity<List<NamedReference>> {
         return ResponseEntity.status(200).body(
             keywords.map {
-                ApiKeyword(id = 1, name = it.name, value = it.value, type = it.type, framework = it.framework)
+                NamedReference(id = 1, name = it.name, value = it.value, type = it.type, framework = it.framework)
             }
         )
     }
@@ -70,8 +70,8 @@ class NamedReferencesController @Autowired constructor(
     fun updateNamedReference(
         @PathVariable id: Int,
         @RequestBody apiKeyword: ApiKeywordUpdate
-    ): HttpEntity<ApiKeyword> {
-        return ResponseEntity.status(200).body(ApiKeyword(134, "my name", "my value", KeywordTypeEnum.Keyword, "my framework"))
+    ): HttpEntity<NamedReference> {
+        return ResponseEntity.status(200).body(NamedReference(134, "my name", "my value", KeywordTypeEnum.Keyword, "my framework"))
     }
 
     @DeleteMapping(RoutePaths.NAMED_REFERENCES_REMOVE)

--- a/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
@@ -12,7 +12,6 @@ import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS
 import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS_UPDATE
 import edu.wgu.osmt.RoutePaths.COLLECTION_UPDATE
 import edu.wgu.osmt.RoutePaths.COLLECTION_XLSX
-import edu.wgu.osmt.RoutePaths.JOB_CODE_PATH
 import edu.wgu.osmt.RoutePaths.SEARCH_COLLECTIONS
 import edu.wgu.osmt.RoutePaths.SEARCH_JOBCODES_PATH
 import edu.wgu.osmt.RoutePaths.SEARCH_KEYWORDS_PATH
@@ -86,7 +85,6 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             .mvcMatchers(GET, TASK_DETAIL_BATCH).authenticated()
             .mvcMatchers(GET, SEARCH_JOBCODES_PATH).authenticated()
             .mvcMatchers(GET, SEARCH_KEYWORDS_PATH).authenticated()
-            // .mvcMatchers(JOB_CODE_PATH).hasAnyAuthority("ROLE_Osmt_View", "ROLE_Osmt_Admin")
 
             // public search endpoints
             .mvcMatchers(POST, SEARCH_SKILLS).permitAll()
@@ -133,7 +131,6 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             .mvcMatchers(POST, SKILL_UPDATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, SKILLS_CREATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, SKILL_PUBLISH).hasAnyAuthority(ADMIN)
-            // .mvcMatchers(JOB_CODE_PATH).hasAnyAuthority(ADMIN, VIEW)
 
             .mvcMatchers(POST, COLLECTION_CREATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, COLLECTION_PUBLISH).hasAnyAuthority(ADMIN)

--- a/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/edu/wgu/osmt/security/SecurityConfig.kt
@@ -12,6 +12,7 @@ import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS
 import edu.wgu.osmt.RoutePaths.COLLECTION_SKILLS_UPDATE
 import edu.wgu.osmt.RoutePaths.COLLECTION_UPDATE
 import edu.wgu.osmt.RoutePaths.COLLECTION_XLSX
+import edu.wgu.osmt.RoutePaths.JOB_CODE_PATH
 import edu.wgu.osmt.RoutePaths.SEARCH_COLLECTIONS
 import edu.wgu.osmt.RoutePaths.SEARCH_JOBCODES_PATH
 import edu.wgu.osmt.RoutePaths.SEARCH_KEYWORDS_PATH
@@ -34,6 +35,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod.*
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
@@ -58,6 +60,7 @@ import javax.servlet.http.HttpServletResponse
 @Configuration
 @EnableWebSecurity
 @Profile("oauth2-okta | OTHER-OAUTH-PROFILE")
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 class SecurityConfig : WebSecurityConfigurerAdapter() {
 
     @Autowired
@@ -83,6 +86,7 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             .mvcMatchers(GET, TASK_DETAIL_BATCH).authenticated()
             .mvcMatchers(GET, SEARCH_JOBCODES_PATH).authenticated()
             .mvcMatchers(GET, SEARCH_KEYWORDS_PATH).authenticated()
+            // .mvcMatchers(JOB_CODE_PATH).hasAnyAuthority("ROLE_Osmt_View", "ROLE_Osmt_Admin")
 
             // public search endpoints
             .mvcMatchers(POST, SEARCH_SKILLS).permitAll()
@@ -129,6 +133,7 @@ class SecurityConfig : WebSecurityConfigurerAdapter() {
             .mvcMatchers(POST, SKILL_UPDATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, SKILLS_CREATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, SKILL_PUBLISH).hasAnyAuthority(ADMIN)
+            // .mvcMatchers(JOB_CODE_PATH).hasAnyAuthority(ADMIN, VIEW)
 
             .mvcMatchers(POST, COLLECTION_CREATE).hasAnyAuthority(ADMIN, CURATOR)
             .mvcMatchers(POST, COLLECTION_PUBLISH).hasAnyAuthority(ADMIN)

--- a/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
@@ -1,5 +1,8 @@
 package edu.wgu.osmt.jobcode
 
+import edu.wgu.osmt.BaseDockerizedTest
+import edu.wgu.osmt.HasDatabaseReset
+import edu.wgu.osmt.HasElasticsearchReset
 import edu.wgu.osmt.SpringTest
 import edu.wgu.osmt.api.model.JobCodeUpdate
 import org.assertj.core.api.Assertions
@@ -15,7 +18,7 @@ import java.time.ZoneOffset
 internal class JobCodeControllerTest @Autowired constructor(
     val jobCodeEsRepo: JobCodeEsRepo,
     val jobCodeRepository: JobCodeRepository
-) : SpringTest() {
+) : SpringTest(), BaseDockerizedTest, HasDatabaseReset {
 
     @Autowired
     lateinit var jobCodeController: JobCodeController

--- a/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
@@ -40,16 +40,19 @@ internal class JobCodeControllerTest @Autowired constructor(
 
     @Test
     fun `By id should find a job code`() {
-        dao.new {
+        val daoJobCode = dao.new {
             this.code = "code"
             this.framework = "framework"
             this.name = "targetNodeName"
             this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
             this.name = "my name"
             this.major = "my major"
-        }.also { jobCodeEsRepo.save(it.toModel()) }
-        val result = jobCodeController.byId(1)
-        Assertions.assertThat(result.body).isNotNull
+        }
+        val esJobCode = jobCodeEsRepo.save(jobCodeEsRepo.save(daoJobCode.toModel()))
+        val result = esJobCode.id?.let { jobCodeController.byId(it) }
+        if (result != null) {
+            Assertions.assertThat(result.body).isNotNull
+        }
         Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
     }
 

--- a/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
@@ -2,7 +2,6 @@ package edu.wgu.osmt.jobcode
 
 import edu.wgu.osmt.BaseDockerizedTest
 import edu.wgu.osmt.HasDatabaseReset
-import edu.wgu.osmt.HasElasticsearchReset
 import edu.wgu.osmt.SpringTest
 import edu.wgu.osmt.api.model.JobCodeUpdate
 import org.assertj.core.api.Assertions

--- a/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/jobcode/JobCodeControllerTest.kt
@@ -1,0 +1,81 @@
+package edu.wgu.osmt.jobcode
+
+import edu.wgu.osmt.SpringTest
+import edu.wgu.osmt.api.model.JobCodeUpdate
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Transactional
+internal class JobCodeControllerTest @Autowired constructor(
+    val jobCodeEsRepo: JobCodeEsRepo,
+    val jobCodeRepository: JobCodeRepository
+) : SpringTest() {
+
+    @Autowired
+    lateinit var jobCodeController: JobCodeController
+    val dao = JobCodeDao.Companion
+
+    @Test
+    fun `Index should return an array with almost one job code`() {
+        dao.new {
+            this.code = "code"
+            this.framework = "framework"
+            this.name = "targetNodeName"
+            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
+            this.name = "my name"
+            this.major = "my major"
+        }.also { jobCodeEsRepo.save(it.toModel()) }
+        val result = jobCodeController.allPaginated(50, 0, null)
+        Assertions.assertThat(result.body).hasSizeGreaterThan(0)
+    }
+
+    @Test
+    fun `By id should find a job code`() {
+        dao.new {
+            this.code = "code"
+            this.framework = "framework"
+            this.name = "targetNodeName"
+            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
+            this.name = "my name"
+            this.major = "my major"
+        }.also { jobCodeEsRepo.save(it.toModel()) }
+        val result = jobCodeController.byId(1)
+        Assertions.assertThat(result.body).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `Create should return created job codes`() {
+        val result = jobCodeController.createJobCode(
+            listOf(JobCodeUpdate("my code", "my framework"))
+        )
+        Assertions.assertThat(result.body).hasSizeGreaterThan(0)
+    }
+
+    @Test
+    fun `Update should return job codes with updated properties`() {
+        val result = jobCodeController.updateJobCode(
+            1,
+            JobCodeUpdate("my code", "my framework")
+        )
+        Assertions.assertThat(result).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `Delete should return status 200`() {
+        val result = jobCodeController.deleteJobCode(
+            1
+        )
+        Assertions.assertThat(result).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+
+}

--- a/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
@@ -1,0 +1,80 @@
+package edu.wgu.osmt.keyword
+
+import edu.wgu.osmt.SpringTest
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Transactional
+internal class NamedReferencesControllerTest @Autowired constructor(
+    val keywordRepository: KeywordRepository,
+    val keywordEsRepo: KeywordEsRepo
+) : SpringTest() {
+
+    @Autowired
+    lateinit var namedReferencesController: NamedReferencesController
+
+    val dao = KeywordDao.Companion
+
+    @Test
+    fun `Index should return an array with almost one named reference`() {
+        dao.new {
+            this.uri = "uri"
+            this.value = "value"
+            this.framework = "my framework"
+            this.type = KeywordTypeEnum.Keyword
+            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
+            this.updateDate = LocalDateTime.now(ZoneOffset.UTC)
+        }.also { keywordEsRepo.save(it.toModel()) }
+        val result = namedReferencesController.allPaginated(KeywordTypeEnum.Keyword.toString(), 50, 0, null)
+        Assertions.assertThat(result.body).hasSizeGreaterThan(0)
+    }
+
+    @Test
+    fun `By id should find a named reference`() {
+        dao.new {
+            this.uri = "uri"
+            this.value = "value"
+            this.framework = "my framework"
+            this.type = KeywordTypeEnum.Keyword
+            this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
+            this.updateDate = LocalDateTime.now(ZoneOffset.UTC)
+        }.also { keywordEsRepo.save(it.toModel()) }
+        val result = namedReferencesController.byId(1)
+        Assertions.assertThat(result.body).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `Create should return created job codes`() {
+        val result = namedReferencesController.createNamedReference(
+            listOf(ApiKeywordUpdate("my keyword", "my value", KeywordTypeEnum.Keyword, "my framework"))
+        )
+        Assertions.assertThat(result.body).hasSizeGreaterThan(0)
+    }
+
+    @Test
+    fun `Update should return job codes with updated properties`() {
+        val result = namedReferencesController.updateNamedReference(
+            1,
+            ApiKeywordUpdate("my keyword", "my value", KeywordTypeEnum.Keyword, "my framework")
+        )
+        Assertions.assertThat(result).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
+    fun `Delete should return status 200`() {
+        val result = namedReferencesController.deleteNamedReference(
+            1
+        )
+        Assertions.assertThat(result).isNotNull
+        Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+}

--- a/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
@@ -39,16 +39,19 @@ internal class NamedReferencesControllerTest @Autowired constructor(
 
     @Test
     fun `By id should find a named reference`() {
-        dao.new {
+        val daoKeyword = dao.new {
             this.uri = "uri"
             this.value = "value"
             this.framework = "my framework"
             this.type = KeywordTypeEnum.Keyword
             this.creationDate = LocalDateTime.now(ZoneOffset.UTC)
             this.updateDate = LocalDateTime.now(ZoneOffset.UTC)
-        }.also { keywordEsRepo.save(it.toModel()) }
-        val result = namedReferencesController.byId(1)
-        Assertions.assertThat(result.body).isNotNull
+        }
+        val esKeyword = keywordEsRepo.save(daoKeyword.toModel())
+        val result = esKeyword.id?.let { namedReferencesController.byId(it) }
+        if (result != null) {
+            Assertions.assertThat(result.body).isNotNull
+        }
         Assertions.assertThat((result as ResponseEntity).statusCode).isEqualTo(HttpStatus.OK)
     }
 

--- a/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
+++ b/api/src/test/kotlin/edu/wgu/osmt/keyword/NamedReferencesControllerTest.kt
@@ -1,5 +1,7 @@
 package edu.wgu.osmt.keyword
 
+import edu.wgu.osmt.BaseDockerizedTest
+import edu.wgu.osmt.HasDatabaseReset
 import edu.wgu.osmt.SpringTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
@@ -14,7 +16,7 @@ import java.time.ZoneOffset
 internal class NamedReferencesControllerTest @Autowired constructor(
     val keywordRepository: KeywordRepository,
     val keywordEsRepo: KeywordEsRepo
-) : SpringTest() {
+) : SpringTest(), BaseDockerizedTest, HasDatabaseReset {
 
     @Autowired
     lateinit var namedReferencesController: NamedReferencesController

--- a/ui/src/app/my-workspace/my-workspace.component.spec.ts
+++ b/ui/src/app/my-workspace/my-workspace.component.spec.ts
@@ -32,6 +32,7 @@ import {LabelWithFilterComponent} from "../table/skills-library-table/label-with
 import {SkillListRowComponent} from "../richskill/list/skill-list-row.component"
 import {StatusBarComponent} from "../core/status-bar.component"
 import {DotsMenuComponent} from "../table/skills-library-table/dots-menu.component"
+import { ConvertToCollectionComponent } from "./convert-to-collection/convert-to-collection.component"
 
 describe("MyWorkspaceComponent", () => {
   let component: MyWorkspaceComponent
@@ -45,6 +46,10 @@ describe("MyWorkspaceComponent", () => {
           {
             path: "my-workspace/uuid1/add-skills",
             component: ManageCollectionComponent
+          },
+          {
+            path: "my-workspace/convert-to-collection",
+            component: ConvertToCollectionComponent
           }
         ]),
         HttpClientTestingModule,


### PR DESCRIPTION
# Security
- Add  `@EnableGlobalMethodSecurity` to use `@PreAuthorize`
- Use  `@PreAuthorize` for security in controllers

# Job Codes
## Available for all authenticated users
- Get all job codes with pagination
- Get job code by ID

## Available for admin role
- Create one or more job codes
- Update a job code
- Delete a job code


# Named References
## Available for all authenticated users
- Get all named references with pagination
- Get named reference by ID

## Available for admin role
- Create one or more named references
- Update a named reference
- Delete a named reference

<br>

> Some request contains a little logic to save and return data, but important changes are related to match with the "open api file" in PR #391 