### PR TITLE
Fix UI tests: Cannot match any routes

### DIFF
--- a/ui/src/app/my-workspace/my-workspace.component.spec.ts
+++ b/ui/src/app/my-workspace/my-workspace.component.spec.ts
@@ -32,6 +32,7 @@ import {LabelWithFilterComponent} from "../table/skills-library-table/label-with
 import {SkillListRowComponent} from "../richskill/list/skill-list-row.component"
 import {StatusBarComponent} from "../core/status-bar.component"
 import {DotsMenuComponent} from "../table/skills-library-table/dots-menu.component"
+import { ConvertToCollectionComponent } from "./convert-to-collection/convert-to-collection.component"
 
 describe("MyWorkspaceComponent", () => {
   let component: MyWorkspaceComponent
@@ -45,6 +46,10 @@ describe("MyWorkspaceComponent", () => {
           {
             path: "my-workspace/uuid1/add-skills",
             component: ManageCollectionComponent
+          },
+          {
+            path: "my-workspace/convert-to-collection",
+            component: ConvertToCollectionComponent
           }
         ]),
         HttpClientTestingModule,


### PR DESCRIPTION
UI Tests are failing (on local and GitHub Actions) due to

`Unhandled promise rejection: Error: Cannot match any routes. URL Segment: 'my-workspace/convert-to-collection'`

I have added a route to `my-workspace.component.spec.ts` to solve the issue.