### PR TITLE
Add API versioning to Angular App

### DIFF
--- a/ui/src/app/abstract.service.spec.ts
+++ b/ui/src/app/abstract.service.spec.ts
@@ -190,7 +190,7 @@ describe("AbstractService (HTTP needed)", () => {
 
   it("buildUrl should return", () => {
     const path = "data"
-    expect(testService.buildUrl(path)).toEqual(AppConfig.settings.baseApiUrl + "/api/" + path)
+    expect(testService.buildUrl(path)).toEqual(AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path)
   })
 
   /* See https://angular.io/guide/http#testing-http-requests */
@@ -213,7 +213,7 @@ describe("AbstractService (HTTP needed)", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -224,7 +224,7 @@ describe("AbstractService (HTTP needed)", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const path = "any/path"
-    const fullUrl = `${AppConfig.settings.baseApiUrl}/api/${path}`
+    const fullUrl = `${AppConfig.settings.baseApiUrl}${getBaseApi()}/${path}`
     const testData: Data = { foo: "bar" }  // Data that is unlikely to exist in any AbstractService derivative
     const errorMsg = `Could not unwrap Data exception...`
 
@@ -249,8 +249,8 @@ describe("AbstractService (HTTP needed)", () => {
   it("bulkStatusChange should return", () => {
     // Arrange
     const newStatus = PublishStatus.Draft
-    const path = "any/path"
-    const fullUrl = `${AppConfig.settings.baseApiUrl}/api/${path}?newStatus=${newStatus.toString()}`
+    const path = "/any/path"
+    const fullUrl = `${AppConfig.settings.baseApiUrl}${getBaseApi()}/${path}?newStatus=${newStatus.toString()}`
     const query = "my query string"
     const apiSearch = new ApiSearch({ query })
     const expected = new ApiTaskResult(createMockTaskResult())
@@ -277,7 +277,7 @@ describe("AbstractService (HTTP needed)", () => {
     // Arrange
     const testData: IWork = { foo: "bar" }  // Data that is unlikely to exist in any AbstractService derivative
     const path = "tasks/42"
-    const fullUrl = AppConfig.settings.baseApiUrl + "/api/" + path
+    const fullUrl = AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path
     const worker = new Work(testData)
 
     // Act
@@ -296,8 +296,8 @@ describe("AbstractService (HTTP needed)", () => {
   it("pollForTaskResult should error", (done) => {
     // Arrange
     const testData: IWork = { foo: "bar" }  // Data that is unlikely to exist in any AbstractService derivative
-    const path = "tasks/42"
-    const fullUrl = AppConfig.settings.baseApiUrl + "/api/" + path
+    const path = "/tasks/42"
+    const fullUrl = AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path
     const worker = new Work(testData)
 
     // Act

--- a/ui/src/app/abstract.service.spec.ts
+++ b/ui/src/app/abstract.service.spec.ts
@@ -28,9 +28,9 @@ export class ConcreteService extends AbstractService {
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   public buildUrl(path: string): string {

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -9,6 +9,7 @@ import {ApiSearch, PaginatedSkills} from "./richskill/service/rich-skill-search.
 import {map, share} from "rxjs/operators"
 import {Router} from "@angular/router"
 import {Location} from "@angular/common"
+import { Inject } from "@angular/core"
 
 export interface ApiGetParams {
   path: string,
@@ -43,12 +44,16 @@ export interface IRelatedSkillsService<TEntityId> {
  */
 export abstract class AbstractService {
 
+  protected base = ""
+
   protected constructor(
     protected httpClient: HttpClient,
     protected authService: IAuthService,
     protected router: Router,
-    protected location: Location
+    protected location: Location,
+    @Inject("BASE_API") base: string
   ) {
+    this.base = base
   }
 
   redirectToLogin(error: any): void {
@@ -101,11 +106,12 @@ export abstract class AbstractService {
   }
 
   protected buildUrl(path: string): string {
+    console.log(this.base)
     const baseUrl = AppConfig.settings.baseApiUrl
 
     // if user defined, make sure it delineates between the host and path
     if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
-      return baseUrl + "/" + path
+      return baseUrl + this.base + "/" + path
     } else {
       return baseUrl + path
     }

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -112,7 +112,7 @@ export abstract class AbstractService {
     if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
       return baseUrl + this.baseApi + "/" + path
     } else {
-      return baseUrl + path
+      return baseUrl + this.baseApi + "/" + path
     }
   }
 

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -51,7 +51,7 @@ export abstract class AbstractService {
     protected authService: IAuthService,
     protected router: Router,
     protected location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_URL") base: string
   ) {
     this.base = base
   }
@@ -111,6 +111,7 @@ export abstract class AbstractService {
 
     // if user defined, make sure it delineates between the host and path
     if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
+      console.log(baseUrl + this.base + "/" + path)
       return baseUrl + this.base + "/" + path
     } else {
       return baseUrl + path

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -44,16 +44,16 @@ export interface IRelatedSkillsService<TEntityId> {
  */
 export abstract class AbstractService {
 
-  protected base = ""
+  protected baseApi = ""
 
   protected constructor(
     protected httpClient: HttpClient,
     protected authService: IAuthService,
     protected router: Router,
     protected location: Location,
-    @Inject("BASE_URL") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    this.base = base
+    this.baseApi = baseApi
   }
 
   redirectToLogin(error: any): void {
@@ -110,7 +110,7 @@ export abstract class AbstractService {
 
     // if user defined, make sure it delineates between the host and path
     if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
-      return baseUrl + this.base + "/" + path
+      return baseUrl + this.baseApi + "/" + path
     } else {
       return baseUrl + path
     }

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -106,12 +106,10 @@ export abstract class AbstractService {
   }
 
   protected buildUrl(path: string): string {
-    console.log(this.base)
     const baseUrl = AppConfig.settings.baseApiUrl
 
     // if user defined, make sure it delineates between the host and path
     if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
-      console.log(baseUrl + this.base + "/" + path)
       return baseUrl + this.base + "/" + path
     } else {
       return baseUrl + path

--- a/ui/src/app/api-version.spec.ts
+++ b/ui/src/app/api-version.spec.ts
@@ -1,0 +1,20 @@
+import { ApiVersion, getBaseApi } from "./api-versions"
+
+describe("api version", () => {
+
+  it("current version used is v3", () => {
+    const currentVersionIsV3 = getBaseApi().includes("v3")
+    expect(currentVersionIsV3).toBeTrue()
+  })
+
+  it("getBaseApi should not return version", () => {
+    const baseApi = getBaseApi(ApiVersion.API_V2)
+    expect(baseApi).toBe("/api")
+  })
+
+  it("getBaseApi should return version", () => {
+    const baseApi = getBaseApi()
+    expect(baseApi).toBe("/api/v3")
+  })
+
+})

--- a/ui/src/app/api-versions.ts
+++ b/ui/src/app/api-versions.ts
@@ -6,5 +6,5 @@ export function getBaseApi(): string {
 }
 
 function getApiVersion(): string {
-  return environment.apiV2
+  return environment.apiV3
 }

--- a/ui/src/app/api-versions.ts
+++ b/ui/src/app/api-versions.ts
@@ -1,5 +1,10 @@
 import { environment } from "../environments/environment"
 
 export function getBaseApi(): string {
-  return "/api/" + environment.apiV2
+  const version = getApiVersion()
+  return "/api" + (version.length > 0 ? "/" : "") + version
+}
+
+function getApiVersion(): string {
+  return environment.apiV2
 }

--- a/ui/src/app/api-versions.ts
+++ b/ui/src/app/api-versions.ts
@@ -1,0 +1,5 @@
+import { environment } from "../environments/environment"
+
+export function getBaseApi(): string {
+  return "/api/" + environment.apiV2
+}

--- a/ui/src/app/api-versions.ts
+++ b/ui/src/app/api-versions.ts
@@ -1,10 +1,13 @@
 import { environment } from "../environments/environment"
 
-export function getBaseApi(): string {
-  const version = getApiVersion()
-  return "/api" + (version.length > 0 ? "/" : "") + version
+export enum ApiVersion {
+  /**
+   * @deprecated
+   */
+  API_V2 = "",
+  API_V3 = "v3"
 }
 
-function getApiVersion(): string {
-  return environment.apiV3
+export function getBaseApi(version: ApiVersion = ApiVersion.API_V3): string {
+  return "/api" + (version.length > 0 ? "/" : "") + version
 }

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -110,6 +110,7 @@ import { OsmtFormModule } from "./form/osmt-form.module"
 import { ConvertToCollectionComponent } from "./my-workspace/convert-to-collection/convert-to-collection.component"
 import { SizePaginationComponent } from "./table/skills-library-table/size-pagination/size-pagination.component"
 import {OsmtTableModule} from "./table/osmt-table.module"
+import { getBaseApi } from "./api-versions"
 
 export function initializeApp(
   appConfig: AppConfig,
@@ -250,9 +251,16 @@ export function initializeApp(
     FormDirtyGuard,
     AuthService,
     AuthGuard,
-    { provide: APP_INITIALIZER,
+    {
+      provide: APP_INITIALIZER,
       useFactory: initializeApp,
-      deps: [AppConfig, AuthService], multi: true }
+      deps: [AppConfig, AuthService],
+      multi: true
+    },
+    {
+      provide: "BASE_API",
+      useFactory: getBaseApi,
+    }
   ],
   bootstrap: [AppComponent]
 })

--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -259,7 +259,7 @@ export function initializeApp(
     },
     {
       provide: "BASE_API",
-      useFactory: getBaseApi,
+      useFactory: () =>  getBaseApi(),
     }
   ],
   bootstrap: [AppComponent]

--- a/ui/src/app/category/detail/card/category-detail-card.component.spec.ts
+++ b/ui/src/app/category/detail/card/category-detail-card.component.spec.ts
@@ -11,6 +11,7 @@ import {AuthService} from "../../../auth/auth-service"
 import {AuthServiceStub, CategoryServiceData, CategoryServiceStub} from "../../../../../test/resource/mock-stubs"
 import {CategoryService} from "../../service/category.service"
 import {CategoryDetailCardComponent} from "./category-detail-card.component"
+import { getBaseApi } from "../../../api-versions"
 
 @Component({
   template: ""
@@ -55,6 +56,10 @@ describe("CategoryDetailCardComponent", () => {
         { provide: AuthService, useClass: AuthServiceStub },
         { provide: CategoryService, useClass: CategoryServiceStub },
         { provide: Router, useValue: routerSpy },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     }).compileComponents()
 

--- a/ui/src/app/category/detail/category-detail.component.spec.ts
+++ b/ui/src/app/category/detail/category-detail.component.spec.ts
@@ -15,6 +15,7 @@ import {FilterDropdown} from "../../models/filter-dropdown.model"
 import {AuthService} from "../../auth/auth-service"
 import {AuthServiceStub, CategoryServiceData,CategoryServiceStub} from "../../../../test/resource/mock-stubs"
 import {CategoryService} from "../service/category.service"
+import { getBaseApi } from "../../api-versions"
 
 @Component({
   template: ""
@@ -68,6 +69,10 @@ describe("CategoryDetailComponent", () => {
         { provide: AuthService, useClass: AuthServiceStub },
         { provide: CategoryService, useClass: CategoryServiceStub },
         { provide: Router, useValue: routerSpy },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        }
       ]
     }).compileComponents()
 

--- a/ui/src/app/category/service/category.service.spec.ts
+++ b/ui/src/app/category/service/category.service.spec.ts
@@ -15,6 +15,7 @@ import {AuthService} from "../../auth/auth-service"
 import {EnvironmentService} from "../../core/environment.service"
 import {CategoryService} from "./category.service"
 import {ApiCategory, IKeyword, KeywordSortOrder, PaginatedCategories} from "../ApiCategory"
+import { getBaseApi } from "../../api-versions"
 
 describe("CategoryService", () => {
   let httpClient: HttpClient
@@ -35,7 +36,11 @@ describe("CategoryService", () => {
         CategoryService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
       .compileComponents()

--- a/ui/src/app/category/service/category.service.spec.ts
+++ b/ui/src/app/category/service/category.service.spec.ts
@@ -70,13 +70,13 @@ describe("CategoryService", () => {
     const sort = KeywordSortOrder.SkillCountDesc
     const size = 10
     const from = 20
-    const path = `api/categories?sort=${sort}&size=${size}&from=${from}`
+    const path = `${getBaseApi()}/categories?sort=${sort}&size=${size}&from=${from}`
 
     // Act
     const result = testService.getAllPaginated(size, from, sort)
 
     // Assert
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(CategoryServiceData.paginatedCategories, {
       headers: { "x-total-count": "" + CategoryServiceData.paginatedCategories.totalCount}
@@ -87,7 +87,7 @@ describe("CategoryService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = `api/categories/${CategoryServiceData.category.id}`
+    const path = `${getBaseApi()}/categories/${CategoryServiceData.category.id}`
 
     // Act
     const result$ = testService.getById(CategoryServiceData.category.id.toString())
@@ -99,7 +99,7 @@ describe("CategoryService", () => {
       expect(AuthServiceData.isDown).toEqual(false)
     })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl  + path)
     expect(req.request.method).toEqual("GET")
     req.flush(CategoryServiceData.categoryKeyword)
   })

--- a/ui/src/app/category/service/category.service.ts
+++ b/ui/src/app/category/service/category.service.ts
@@ -27,7 +27,7 @@ export class CategoryService extends AbstractService implements IRelatedSkillsSe
     super(httpClient, authService, router, location, base)
   }
 
-  private serviceUrl = "api/categories"
+  private serviceUrl = "categories"
 
   getAllPaginated(
     size: number = 50,

--- a/ui/src/app/category/service/category.service.ts
+++ b/ui/src/app/category/service/category.service.ts
@@ -1,6 +1,6 @@
 import {Location} from "@angular/common"
 import {HttpClient, HttpHeaders} from "@angular/common/http"
-import {Injectable} from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import {Router} from "@angular/router"
 import {Observable} from "rxjs"
 import {map, share} from "rxjs/operators"
@@ -17,8 +17,14 @@ import {ApiCategory, IKeyword, KeywordSortOrder, PaginatedCategories} from "../A
 })
 export class CategoryService extends AbstractService implements IRelatedSkillsService<number> {
 
-  constructor(httpClient: HttpClient, authService: AuthService, router: Router, location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    httpClient: HttpClient,
+    authService: AuthService,
+    router: Router,
+    location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   private serviceUrl = "api/categories"

--- a/ui/src/app/category/service/category.service.ts
+++ b/ui/src/app/category/service/category.service.ts
@@ -22,9 +22,9 @@ export class CategoryService extends AbstractService implements IRelatedSkillsSe
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   private serviceUrl = "categories"

--- a/ui/src/app/collection/service/collection.service.spec.ts
+++ b/ui/src/app/collection/service/collection.service.spec.ts
@@ -31,6 +31,7 @@ import {
 import { ApiTaskResult, ITaskResult } from "../../task/ApiTaskResult"
 import { ApiCollection, ApiCollectionUpdate } from "../ApiCollection"
 import { CollectionService } from "./collection.service"
+import { getBaseApi } from "../../api-versions"
 
 
 const ASYNC_WAIT_PERIOD = 3000
@@ -54,7 +55,11 @@ describe("CollectionService", () => {
         CollectionService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        }
       ]
     })
     .compileComponents()
@@ -499,7 +504,7 @@ describe("CollectionService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))
@@ -512,7 +517,7 @@ describe("CollectionService", () => {
     const taskResult = createMockTaskResult()
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
-    const path1 = "api/collections/publish"
+    const path1 = "collections/publish"
     const path2 = taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })

--- a/ui/src/app/collection/service/collection.service.spec.ts
+++ b/ui/src/app/collection/service/collection.service.spec.ts
@@ -537,7 +537,7 @@ describe("CollectionService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path1 +
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1 +
       `?newStatus=${newStatus}&filterByStatus=${PublishStatus.Draft}`)
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
@@ -545,7 +545,7 @@ describe("CollectionService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))

--- a/ui/src/app/collection/service/collection.service.spec.ts
+++ b/ui/src/app/collection/service/collection.service.spec.ts
@@ -86,7 +86,7 @@ describe("CollectionService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/collections?sort=name.asc&status=draft&size=3&from=0"
+    const path = getBaseApi() + "/collections?sort=name.asc&status=draft&size=3&from=0"
     const testData: PaginatedCollections = createMockPaginatedCollections(3, 10)
     const statuses = new Set<PublishStatus>([ PublishStatus.Draft ])
 
@@ -102,7 +102,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData.collections, {
       headers: { "x-total-count": "" + testData.totalCount}
@@ -114,7 +114,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "uuid1"
-    const path = "api/collections/" + uuid
+    const path = getBaseApi() + "/collections/" + uuid
     const date = new Date("2020-06-25T14:58:46.313Z")
     const testData: ApiCollection = new ApiCollection(createMockCollection(date, date, date, date, PublishStatus.Draft))
 
@@ -130,7 +130,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -140,7 +140,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "uuid1"
-    const path = "api/collections/" + uuid
+    const path = getBaseApi() + "/collections/" + uuid
     const date = new Date("2020-06-25T14:58:46.313Z")
     const testData: ApiCollection = new ApiCollection(createMockCollection(date, date, date, date, PublishStatus.Draft))
 
@@ -156,7 +156,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -179,7 +179,7 @@ describe("CollectionService", () => {
 
   it("requestCollectionSkillsXlsx", () => {
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/collections/" + uuid + "/xlsx"
+    const path = getBaseApi() + "/collections/" + uuid + "/xlsx"
     const result = testService.requestCollectionSkillsXlsx(uuid)
     const testData = createMockTaskResult()
     const expected = new ApiTaskResult(testData)
@@ -188,7 +188,7 @@ describe("CollectionService", () => {
       expect(data).toEqual(expected)
     })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -198,7 +198,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/results/media/" + uuid
+    const path = getBaseApi() + "/results/media/" + uuid
     const blob = new Blob([""], { type: "application/vnd.ms-excel" })
 
     // Act
@@ -208,7 +208,7 @@ describe("CollectionService", () => {
       expect(data.body).toEqual(blob)
     })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(blob)
   })
@@ -218,7 +218,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/collections/" + uuid + "/csv"
+    const path = getBaseApi() + "/collections/" + uuid + "/csv"
     const testData = createMockTaskResult()
     const expected = new ApiTaskResult(testData)
 
@@ -233,7 +233,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -261,7 +261,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/results/text/" + uuid
+    const path = getBaseApi() + "/results/text/" + uuid
     const testData = { foo: "bar" }
     const expected = testData
 
@@ -276,7 +276,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -286,7 +286,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/collections/" + uuid + "/skills?sort=undefined"
+    const path = getBaseApi() + "/collections/" + uuid + "/skills?sort=undefined"
     const testData = createMockPaginatedSkills()
     const expected = testData
 
@@ -301,7 +301,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData.skills, {
       headers: { "x-total-count": "" + testData.totalCount}
@@ -312,7 +312,7 @@ describe("CollectionService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/collections"
+    const path = getBaseApi() + "/collections"
     const now = new Date()
     const testData = [
       new ApiCollection(createMockCollection(
@@ -343,7 +343,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })
@@ -361,7 +361,7 @@ describe("CollectionService", () => {
     const stringListUpdate: IStringListUpdate = { add: [], remove: [] }
     const expected = testData
     const uuid = expected.uuid
-    const path = "api/collections/" + uuid + "/update"
+    const path = getBaseApi() + "/collections/" + uuid + "/update"
     expected.skills.forEach(s => stringListUpdate.add?.push(s))
     const input = new ApiCollectionUpdate({
       name: expected.name,
@@ -382,7 +382,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })
@@ -393,7 +393,7 @@ describe("CollectionService", () => {
     AuthServiceData.isDown = false
     const testData: PaginatedCollections = createMockPaginatedCollections()
     const expected = testData
-    const path = "api/search/collections"
+    const path = getBaseApi() + "/search/collections"
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
     const size = 5
@@ -412,7 +412,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path +
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path +
         `?sort=${sort}&status=${PublishStatus.Published}&status=${PublishStatus.Draft}&size=${size}&from=${from}`)
     expect(req.request.method).toEqual("POST")
     req.flush(testData.collections, {
@@ -427,7 +427,7 @@ describe("CollectionService", () => {
     const testData = createMockTaskResult()
     const expected = new ApiTaskResult(testData)
     const uuid = expected.uuid
-    const path = "api/collections/" + uuid + "/updateSkills"
+    const path = getBaseApi() + "/collections/" + uuid + "/updateSkills"
     const query = "testQueryString"
     const update = new ApiSkillListUpdate({
       add: new ApiSearch({query}),
@@ -447,7 +447,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path +
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path +
       `?sort=${sort}&status=${PublishStatus.Published}&status=${PublishStatus.Draft}`)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
@@ -460,7 +460,7 @@ describe("CollectionService", () => {
     result$.subscribe((data: ApiBatchResult) => {
       expect(RouterData.commands).toEqual([]) // No Errors
     })
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + `/api/collections/${apiTaskResultForDeleteCollection.uuid}/remove`)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + `${getBaseApi()}/collections/${apiTaskResultForDeleteCollection.uuid}/remove`)
     expect(req.request.method).toEqual("DELETE")
     expect(req.request.headers.get("Accept")).toEqual("application/json")
   }))
@@ -473,8 +473,8 @@ describe("CollectionService", () => {
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
     const uuid: string = taskResult.uuid ? taskResult.uuid : ""
-    const path1 = "api/collections/" + uuid + "/updateSkills"
-    const path2 = taskResult.id
+    const path1 = getBaseApi() + "/collections/" + uuid + "/updateSkills"
+    const path2 = getBaseApi() + "/" + taskResult.id
     const query = "testQueryString"
     const update = new ApiSkillListUpdate({
       add: new ApiSearch({query}),
@@ -496,7 +496,7 @@ describe("CollectionService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path1 +
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path1 +
       `?sort=${sort}&status=${PublishStatus.Published}&status=${PublishStatus.Draft}`)
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
@@ -504,7 +504,7 @@ describe("CollectionService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))
@@ -517,8 +517,8 @@ describe("CollectionService", () => {
     const taskResult = createMockTaskResult()
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
-    const path1 = "collections/publish"
-    const path2 = taskResult.id
+    const path1 = getBaseApi() + "/collections/publish"
+    const path2 = getBaseApi() + "/" + taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
     const filter = new Set<PublishStatus>([PublishStatus.Draft])
@@ -537,7 +537,7 @@ describe("CollectionService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1 +
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path1 +
       `?newStatus=${newStatus}&filterByStatus=${PublishStatus.Draft}`)
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
@@ -545,7 +545,7 @@ describe("CollectionService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))
@@ -555,7 +555,7 @@ describe("CollectionService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/collections/" + uuid + "/skills"
+    const path = getBaseApi() + "/collections/" + uuid + "/skills"
     const testData = createMockPaginatedSkills(0, 0)
     const expected = true
     const size = 1
@@ -573,7 +573,7 @@ describe("CollectionService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path +
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path +
       `?sort=${sort}&status=${PublishStatus.Archived}&status=${PublishStatus.Draft}&size=${size}&from=${from}`)
     expect(req.request.method).toEqual("POST")
     req.flush(testData.skills, {

--- a/ui/src/app/collection/service/collection.service.ts
+++ b/ui/src/app/collection/service/collection.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import {HttpClient, HttpHeaders} from "@angular/common/http"
 import {AuthService} from "../../auth/auth-service"
 import {AbstractService} from "../../abstract.service"
@@ -38,10 +38,16 @@ import {Location} from "@angular/common"
 })
 export class CollectionService extends AbstractService {
 
-  private baseServiceUrl = "api/collections"
+  private baseServiceUrl = "collections"
 
-  constructor(httpClient: HttpClient, authService: AuthService, router: Router, location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    httpClient: HttpClient,
+    authService: AuthService,
+    router: Router,
+    location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   getCollections(

--- a/ui/src/app/collection/service/collection.service.ts
+++ b/ui/src/app/collection/service/collection.service.ts
@@ -113,7 +113,7 @@ export class CollectionService extends AbstractService {
   // tslint:disable-next-line:no-any
   getCsvTaskResultsIfComplete(uuid: string): Observable<any> {
     return this.httpClient
-      .get(this.buildUrl(`/api/results/text/${uuid}`), {
+      .get(this.buildUrl(`results/text/${uuid}`), {
         responseType: "text",
         observe: "response"
       })
@@ -137,7 +137,7 @@ export class CollectionService extends AbstractService {
   // tslint:disable-next-line:no-any
   getXlsxTaskResultsIfComplete(uuid: string): Observable<any> {
     return this.httpClient
-      .get(this.buildUrl(`/api/results/media/${uuid}`), {
+      .get(this.buildUrl(`results/media/${uuid}`), {
         responseType: "blob" as "json",
         observe: "response",
       })
@@ -169,7 +169,7 @@ export class CollectionService extends AbstractService {
   getWorkspace(): Observable<ApiCollection> {
     const errorMsg = `Could not find workspace`
     return this.get<ICollection>({
-      path: "api/workspace"
+      path: "workspace"
     })
       .pipe(share())
       .pipe(map(({body}) => this.collectionFromApiResponse(body, errorMsg)))
@@ -206,7 +206,7 @@ export class CollectionService extends AbstractService {
     const params = this.buildTableParams(size, from, filterByStatuses, sort)
 
     return this.post<ICollectionSummary[]>({
-      path: "api/search/collections",
+      path: "search/collections",
       params,
       body: apiSearch
     })
@@ -224,7 +224,7 @@ export class CollectionService extends AbstractService {
   ): Observable<ApiTaskResult> {
     const params = this.buildTableParams(undefined, undefined, filterByStatuses, undefined)
     return this.post<ITaskResult>({
-      path: `api/collections/${collectionUuid}/updateSkills`,
+      path: `collections/${collectionUuid}/updateSkills`,
       params,
       body: skillListUpdate
     })
@@ -245,7 +245,7 @@ export class CollectionService extends AbstractService {
   }
 
   deleteCollection(uuid: string): Observable<ApiTaskResult> {
-    return this.httpClient.delete<ITaskResult>(this.buildUrl("api/collections/" + uuid + "/remove"), {
+    return this.httpClient.delete<ITaskResult>(this.buildUrl("collections/" + uuid + "/remove"), {
       headers: this.wrapHeaders(new HttpHeaders({
           Accept: "application/json"
         }
@@ -262,7 +262,7 @@ export class CollectionService extends AbstractService {
     pollIntervalMs: number = 1000,
   ): Observable<ApiBatchResult> {
     return this.pollForTaskResult<ApiBatchResult>(
-      this.bulkStatusChange("api/collections/publish", apiSearch, newStatus, filterByStatuses),
+      this.bulkStatusChange("collections/publish", apiSearch, newStatus, filterByStatuses),
       pollIntervalMs
     )
   }

--- a/ui/src/app/collection/service/collection.service.ts
+++ b/ui/src/app/collection/service/collection.service.ts
@@ -45,9 +45,9 @@ export class CollectionService extends AbstractService {
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   getCollections(

--- a/ui/src/app/data/abstract-data.service.spec.ts
+++ b/ui/src/app/data/abstract-data.service.spec.ts
@@ -7,6 +7,7 @@ import { EnvironmentService } from "../core/environment.service"
 import { AppConfig } from "../app.config"
 import { AuthService } from "../auth/auth-service"
 import { AuthServiceStub, RouterStub } from "@test/resource/mock-stubs"
+import { getBaseApi } from "../api-versions"
 
 describe("AbstractAdminService", () => {
   let testService: AbstractDataService
@@ -20,7 +21,11 @@ describe("AbstractAdminService", () => {
         AbstractDataService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]})
     testService = TestBed.inject(AbstractDataService)
   })

--- a/ui/src/app/data/abstract-data.service.ts
+++ b/ui/src/app/data/abstract-data.service.ts
@@ -15,9 +15,9 @@ export abstract class AbstractDataService extends AbstractService {
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   /**

--- a/ui/src/app/data/abstract-data.service.ts
+++ b/ui/src/app/data/abstract-data.service.ts
@@ -1,6 +1,6 @@
 import { Location } from "@angular/common"
 import { HttpClient, HttpResponse } from "@angular/common/http"
-import { Injectable } from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import { Router } from "@angular/router"
 import { Observable } from "rxjs"
 import { share } from "rxjs/operators"
@@ -10,8 +10,14 @@ import { AuthService } from "../auth/auth-service"
 @Injectable({ providedIn: "root" })
 export abstract class AbstractDataService extends AbstractService {
 
-  protected constructor(httpClient: HttpClient, authService: AuthService, router: Router, location: Location) {
-    super(httpClient, authService, router, location)
+  protected constructor(
+    httpClient: HttpClient,
+    authService: AuthService,
+    router: Router,
+    location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   /**

--- a/ui/src/app/data/named-reference.service.spec.ts
+++ b/ui/src/app/data/named-reference.service.spec.ts
@@ -7,6 +7,7 @@ import { EnvironmentService } from "../core/environment.service"
 import { AppConfig } from "../app.config"
 import { AuthService } from "../auth/auth-service"
 import { AuthServiceStub, RouterStub } from "@test/resource/mock-stubs"
+import { getBaseApi } from "../api-versions"
 
 describe("NamedReferenceService", () => {
   let testService: NamedReferenceService
@@ -20,7 +21,11 @@ describe("NamedReferenceService", () => {
         NamedReferenceService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]})
     testService = TestBed.inject(NamedReferenceService)
   })

--- a/ui/src/app/data/named-reference.service.ts
+++ b/ui/src/app/data/named-reference.service.ts
@@ -17,8 +17,8 @@ export class NamedReferenceService extends AbstractDataService{
     protected authService: AuthService,
     protected router: Router,
     protected location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 }

--- a/ui/src/app/data/named-reference.service.ts
+++ b/ui/src/app/data/named-reference.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import { HttpClient } from "@angular/common/http"
 import { Router } from "@angular/router"
 import { Location } from "@angular/common"
@@ -10,10 +10,15 @@ import { AbstractDataService } from "./abstract-data.service"
 })
 export class NamedReferenceService extends AbstractDataService{
 
-  private baseServiceUrl = "api/named-references"
+  private baseServiceUrl = "named-references"
 
-  constructor(protected httpClient: HttpClient, protected authService: AuthService,
-              protected router: Router, protected location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    protected httpClient: HttpClient,
+    protected authService: AuthService,
+    protected router: Router,
+    protected location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 }

--- a/ui/src/app/job-codes/service/job-code.service.spec.ts
+++ b/ui/src/app/job-codes/service/job-code.service.spec.ts
@@ -53,7 +53,7 @@ describe("JobCodeService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/metadata/jobcodes?sort=name.asc&size=3&from=0"
+    const path = getBaseApi() + "/metadata/jobcodes?sort=name.asc&size=3&from=0"
     const testData: PaginatedJobCodes = createMockPaginatedJobCodes(3, 10)
 
     // Act
@@ -68,7 +68,7 @@ describe("JobCodeService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData.jobCodes, {
       headers: { "x-total-count": "" + testData.totalCount}
@@ -80,7 +80,7 @@ describe("JobCodeService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const id = "12345"
-    const path = "api/metadata/jobcodes/" + id
+    const path = getBaseApi() + "/metadata/jobcodes/" + id
     const testData: ApiJobCode = new ApiJobCode(createMockJobcode(42, "my jobcode name", id))
 
     // Act
@@ -95,7 +95,7 @@ describe("JobCodeService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -104,7 +104,7 @@ describe("JobCodeService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/metadata/jobcodes"
+    const path = getBaseApi() + "/metadata/jobcodes"
     const testData = [
       new ApiJobCode(createMockJobcode())
     ]
@@ -129,7 +129,7 @@ describe("JobCodeService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })
@@ -141,7 +141,7 @@ describe("JobCodeService", () => {
     const testData = new ApiJobCode(createMockJobcode())
     const expected = testData
     const id = expected.code
-    const path = "api/metadata/jobcodes/" + id
+    const path = getBaseApi() + "/metadata/jobcodes/" + id
     const input = new ApiJobCodeUpdate({
       code: expected.code,
       targetNodeName: expected.targetNodeName,
@@ -162,7 +162,7 @@ describe("JobCodeService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path + "/update")
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path + "/update")
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })
@@ -174,7 +174,7 @@ describe("JobCodeService", () => {
     result$.subscribe((data: ApiBatchResult) => {
       expect(RouterData.commands).toEqual([]) // No Errors
     })
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + `/api/metadata/jobcodes/${apiTaskResultForDeleteJobCode.uuid}/remove`)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + `${getBaseApi()}/metadata/jobcodes/${apiTaskResultForDeleteJobCode.uuid}/remove`)
     expect(req.request.method).toEqual("DELETE")
     expect(req.request.headers.get("Accept")).toEqual("application/json")
   }))

--- a/ui/src/app/job-codes/service/job-code.service.spec.ts
+++ b/ui/src/app/job-codes/service/job-code.service.spec.ts
@@ -15,6 +15,7 @@ import {
 import { ApiSortOrder } from "../../richskill/ApiSkill"
 import { ApiJobCode, ApiJobCodeUpdate } from "../Jobcode"
 import { ApiBatchResult } from "../../richskill/ApiBatchResult"
+import { getBaseApi } from "../../api-versions"
 
 const ASYNC_WAIT_PERIOD = 3000
 
@@ -32,7 +33,11 @@ describe("JobCodeService", () => {
         JobCodeService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]}).compileComponents()
     testService = TestBed.inject(JobCodeService)
     httpTestingController = TestBed.inject(HttpTestingController)

--- a/ui/src/app/job-codes/service/job-code.service.ts
+++ b/ui/src/app/job-codes/service/job-code.service.ts
@@ -81,7 +81,7 @@ export class JobCodeService extends AbstractDataService{
   }
 
   deleteJobCode(id: string): Observable<ApiTaskResult> {
-    return this.httpClient.delete<ITaskResult>(this.buildUrl("api/metadata/jobcodes/" + id + "/remove"), {
+    return this.httpClient.delete<ITaskResult>(this.buildUrl("metadata/jobcodes/" + id + "/remove"), {
       headers: this.wrapHeaders(new HttpHeaders({
           Accept: "application/json"
         }

--- a/ui/src/app/job-codes/service/job-code.service.ts
+++ b/ui/src/app/job-codes/service/job-code.service.ts
@@ -23,9 +23,9 @@ export class JobCodeService extends AbstractDataService{
     protected authService: AuthService,
     protected router: Router,
     protected location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   getJobCodes(

--- a/ui/src/app/job-codes/service/job-code.service.ts
+++ b/ui/src/app/job-codes/service/job-code.service.ts
@@ -1,6 +1,6 @@
 import { Location } from "@angular/common"
 import { HttpClient, HttpHeaders } from "@angular/common/http"
-import { Injectable } from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import { Router } from "@angular/router"
 import { Observable } from "rxjs"
 import { map, share } from "rxjs/operators"
@@ -16,11 +16,16 @@ import { ApiTaskResult, ITaskResult } from "../../task/ApiTaskResult"
 })
 export class JobCodeService extends AbstractDataService{
 
-  private baseServiceUrl = "api/metadata/jobcodes"
+  private baseServiceUrl = "metadata/jobcodes"
 
-  constructor(protected httpClient: HttpClient, protected authService: AuthService,
-              protected router: Router, protected location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    protected httpClient: HttpClient,
+    protected authService: AuthService,
+    protected router: Router,
+    protected location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   getJobCodes(

--- a/ui/src/app/richskill/detail/rich-skill-manage/rich-skill-manage.component.spec.ts
+++ b/ui/src/app/richskill/detail/rich-skill-manage/rich-skill-manage.component.spec.ts
@@ -13,6 +13,7 @@ import { PublishStatus } from "../../../PublishStatus"
 import { ApiSkill } from "../../ApiSkill"
 import { RichSkillService } from "../../service/rich-skill.service"
 import { RichSkillManageComponent } from "./rich-skill-manage.component"
+import { getBaseApi } from "../../../api-versions"
 
 
 export function createComponent(T: Type<RichSkillManageComponent>): Promise<void> {
@@ -49,6 +50,10 @@ describe("RichSkillManageComponent", () => {
         Title,
         RichSkillService,
         { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
     .compileComponents()

--- a/ui/src/app/richskill/import/batch-import-component.spec.ts
+++ b/ui/src/app/richskill/import/batch-import-component.spec.ts
@@ -9,6 +9,7 @@ import { AppConfig } from "../../app.config"
 import { AuthService } from "../../auth/auth-service"
 import { EnvironmentService } from "../../core/environment.service"
 import { BatchImportComponent } from "./batch-import.component"
+import { getBaseApi } from "../../api-versions"
 
 
 export function createComponent(T: Type<BatchImportComponent>): Promise<void> {
@@ -52,7 +53,11 @@ describe("BatchImportComponent", () => {
         EnvironmentService,
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useValue: routerSpy },
-        { provide: AuthService, useClass: AuthServiceStub }
+        { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        }
       ]
     })
       .compileComponents()

--- a/ui/src/app/richskill/service/keyword-search.service.ts
+++ b/ui/src/app/richskill/service/keyword-search.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import {AbstractService} from "../../abstract.service"
 import {HttpClient} from "@angular/common/http"
 import {AuthService} from "../../auth/auth-service"
@@ -17,8 +17,14 @@ import {Location} from "@angular/common";
 })
 export class KeywordSearchService extends AbstractService {
 
-  constructor(httpClient: HttpClient, authService: AuthService, router: Router, location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    httpClient: HttpClient,
+    authService: AuthService,
+    router: Router,
+    location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   searchJobcodes(

--- a/ui/src/app/richskill/service/keyword-search.service.ts
+++ b/ui/src/app/richskill/service/keyword-search.service.ts
@@ -22,9 +22,9 @@ export class KeywordSearchService extends AbstractService {
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   searchJobcodes(

--- a/ui/src/app/richskill/service/keyword-search.service.ts
+++ b/ui/src/app/richskill/service/keyword-search.service.ts
@@ -33,7 +33,7 @@ export class KeywordSearchService extends AbstractService {
     const errorMsg = `Failed to unwrap response for skill search`
 
     return this.get<IJobCode[]>({
-      path: "api/search/jobcodes",
+      path: "search/jobcodes",
       params: {
         query
       }
@@ -50,7 +50,7 @@ export class KeywordSearchService extends AbstractService {
     const errorMsg = `Failed to unwrap response for skill search`
 
     return this.get<INamedReference[]>({
-      path: "api/search/keywords",
+      path: "search/keywords",
       params: {
         query,
         type

--- a/ui/src/app/richskill/service/rich-skill.service.spec.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.spec.ts
@@ -86,7 +86,7 @@ describe("RichSkillService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/skills/filter?sort=skill.asc&status=draft&size=3&from=0"
+    const path = getBaseApi() + "/skills/filter?sort=skill.asc&status=draft&size=3&from=0"
     const testData: PaginatedSkills = createMockPaginatedSkills(3, 10)
     const statuses = new Set<PublishStatus>([ PublishStatus.Draft ])
 
@@ -102,7 +102,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData.skills, {
       headers: { "x-total-count": "" + testData.totalCount}
@@ -114,7 +114,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "uuid1"
-    const path = "api/skills/" + uuid
+    const path = getBaseApi() + "/skills/" + uuid
     const date = new Date("2020-06-25T14:58:46.313Z")
     const testData: ApiSkill = new ApiSkill(createMockSkill(date, date, PublishStatus.Draft))
 
@@ -130,7 +130,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(testData)
   })
@@ -140,7 +140,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/skills/" + uuid
+    const path = getBaseApi() + "/skills/" + uuid
     const testData =
       "\"Canonical URL\",\"RSD Name\",\"Authors\",\"Skill Statement\",\"Categories\",\"Keywords\",\"Standards\",\"Certifications\",\"Occupation Major Groups\",\"Occupation Minor Groups\",\"Broad Occupations\",\"Detailed Occupations\",\"O*Net Job Codes\",\"Employers\",\"Alignment Name\",\"Alignment URL\"\n" +
       "\"https://localhost:8080/api/skills/f6aacc9e-bfc6-4cc9-924d-c7ef83afef07\",\"Situational Parameters\",\"Western Governors University\",\"Identify appropriate modes of written communication based on situational parameters.\",\"Written Communication\",\"SEL: Interpersonal Communication; Written Communication; Writing; Academic Writing\",\"\",\"\",\"29-0000\",\"29-1000\",\"29-1140\",\"29-1141\",\"29-1141.00; 29-1141.01; 29-1141.02; 29-1141.03; 29-1141.04\",\"Health Open Skills\",\"Written Communication\",\"skills.emsidata.com/skills/KS4425C63RPH46FJ9BX7\""
@@ -157,7 +157,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     expect(req.request.headers.get("Accept")).toEqual("text/csv")
     req.flush(testData)
@@ -180,7 +180,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/skills/" + uuid
+    const path = getBaseApi() + "/skills/" + uuid
     const testData =  // Doesn't matter what the string has in it.
       `{
           "foo": "bar"
@@ -198,7 +198,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     expect(req.request.headers.get("Accept")).toEqual("application/json")
     req.flush(testData)
@@ -224,8 +224,8 @@ describe("RichSkillService", () => {
     const now = new Date()
     const skillResult: ApiSkill = new ApiSkill(createMockSkill(now, now, PublishStatus.Published))
     const expected = skillResult
-    const path1 = "skills"
-    const path2 = taskResult.id
+    const path1 = getBaseApi() + "/skills"
+    const path2 = getBaseApi() + "/" + taskResult.id
     const skillUpdate = createMockSkillUpdate()
 
     // Act
@@ -242,14 +242,14 @@ describe("RichSkillService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1)
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path1)
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
 
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl  + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush([skillResult])
   }))
@@ -259,7 +259,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/skills/" + uuid + "/update"
+    const path = getBaseApi() + "/skills/" + uuid + "/update"
     const skillUpdate: ApiSkillUpdate = createMockSkillUpdate()
     const now = new Date()
     const testData: ApiSkill = new ApiSkill(createMockSkill(now, now, PublishStatus.Draft))
@@ -276,7 +276,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })
@@ -285,7 +285,7 @@ describe("RichSkillService", () => {
     // Arrange
     RouterData.commands = []
     AuthServiceData.isDown = false
-    const path = "api/search/skills"
+    const path = getBaseApi() + "/search/skills"
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
     const size = 5
@@ -306,7 +306,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path +
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path +
       "?sort=skill.asc&status=published&status=draft&size=5&from=1")
     expect(req.request.method).toEqual("POST")
     req.flush(testData.skills, {
@@ -326,7 +326,7 @@ describe("RichSkillService", () => {
       expect(RouterData.commands).toEqual([]) // No Errors
     })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/export/library/csv")
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + getBaseApi() + "/export/library/csv")
     expect(req.request.method).toEqual("GET")
     expect(req.request.headers.get("Accept")).toEqual("application/json")
     req.flush(result$)
@@ -340,7 +340,7 @@ describe("RichSkillService", () => {
     result$.subscribe((data: ApiTaskResult) => {
       expect(RouterData.commands).toEqual([]) // No Errors
     })
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/export/skills/csv?sort=undefined")
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + getBaseApi() + "/export/skills/csv?sort=undefined")
     expect(req.request.method).toEqual("POST")
     expect(req.request.headers.get("Accept")).toEqual("application/json")
     req.flush(result$)
@@ -349,10 +349,10 @@ describe("RichSkillService", () => {
   it("getResultExportedLibrary", fakeAsync(() => {
     {
       const taskResult = apiTaskResultForCSV
-      const path = "api/results/text/" + apiTaskResultForCSV.uuid
+      const path = "/results/text/" + apiTaskResultForCSV.uuid
       const path2 = taskResult.id.slice(1)
       testService.getResultExportedCsvLibrary(path2).subscribe()
-      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path)
+      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path2)
       expect(req1.request.method).toEqual("GET")
       req1.flush("csv")
 
@@ -367,8 +367,8 @@ describe("RichSkillService", () => {
     const taskResult = createMockTaskResult()
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
-    const path1 = "skills/publish"
-    const path2 = taskResult.id
+    const path1 = getBaseApi() + "/skills/publish"
+    const path2 = getBaseApi() + "/" + taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
 
@@ -386,7 +386,7 @@ describe("RichSkillService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1 +
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path1 +
             "?newStatus=published")
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
@@ -394,7 +394,7 @@ describe("RichSkillService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))
@@ -404,7 +404,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const uuid = "f6aacc9e-bfc6-4cc9-924d-c7ef83afef07"
-    const path = "api/skills/" + uuid + "/log"
+    const path = getBaseApi() + "/skills/" + uuid + "/log"
     const auditLogs = [createMockAuditLog()]
     const testData: ApiAuditLog[] = [new ApiAuditLog(auditLogs[0])]
 
@@ -420,7 +420,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("GET")
     req.flush(auditLogs)
   })
@@ -430,7 +430,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const statement = "my statement"
-    const path = "api/search/skills/similarity"
+    const path = getBaseApi() + "/search/skills/similarity"
     const skillSummary = [createMockSkillSummary()]
     const testData: ApiSkillSummary[] = [new ApiSkillSummary(skillSummary[0])]
 
@@ -446,7 +446,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(skillSummary)
   })
@@ -456,7 +456,7 @@ describe("RichSkillService", () => {
     RouterData.commands = []
     AuthServiceData.isDown = false
     const statements = ["my statement"]
-    const path = "api/search/skills/similarities"
+    const path = getBaseApi() + "/search/skills/similarities"
     const testData: boolean[] = [true]
 
     // Act
@@ -471,7 +471,7 @@ describe("RichSkillService", () => {
         expect(AuthServiceData.isDown).toEqual(false)
       })
 
-    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+    const req = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path)
     expect(req.request.method).toEqual("POST")
     req.flush(testData)
   })

--- a/ui/src/app/richskill/service/rich-skill.service.spec.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.spec.ts
@@ -28,6 +28,7 @@ import { ApiSearch, PaginatedSkills } from "./rich-skill-search.service"
 import { RichSkillService } from "./rich-skill.service"
 import { ApiTaskResult } from "../../task/ApiTaskResult"
 import {query} from "@angular/animations"
+import { getBaseApi } from "../../api-versions"
 
 
 // An example of how to test a service
@@ -54,7 +55,11 @@ describe("RichSkillService", () => {
         RichSkillService,
         Location,
         { provide: AuthService, useClass: AuthServiceStub },
-        { provide: Router, useClass: RouterStub }
+        { provide: Router, useClass: RouterStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
     .compileComponents()
@@ -219,7 +224,7 @@ describe("RichSkillService", () => {
     const now = new Date()
     const skillResult: ApiSkill = new ApiSkill(createMockSkill(now, now, PublishStatus.Published))
     const expected = skillResult
-    const path1 = "api/skills"
+    const path1 = "skills"
     const path2 = taskResult.id
     const skillUpdate = createMockSkillUpdate()
 
@@ -347,7 +352,7 @@ describe("RichSkillService", () => {
       const path = "api/results/text/" + apiTaskResultForCSV.uuid
       const path2 = taskResult.id.slice(1)
       testService.getResultExportedCsvLibrary(path2).subscribe()
-      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path)
+      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path)
       expect(req1.request.method).toEqual("GET")
       req1.flush("csv")
 
@@ -362,7 +367,7 @@ describe("RichSkillService", () => {
     const taskResult = createMockTaskResult()
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
-    const path1 = "api/skills/publish"
+    const path1 = "skills/publish"
     const path2 = taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })

--- a/ui/src/app/richskill/service/rich-skill.service.spec.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.spec.ts
@@ -242,14 +242,14 @@ describe("RichSkillService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path1)
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1)
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
 
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush([skillResult])
   }))
@@ -386,7 +386,7 @@ describe("RichSkillService", () => {
 
     /* Service call will make 2 requests: the requested action + the async task result */
     /* Setup for request 1 */
-    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path1 +
+    const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path1 +
             "?newStatus=published")
     expect(req1.request.method).toEqual("POST")
     req1.flush(taskResult)
@@ -394,7 +394,7 @@ describe("RichSkillService", () => {
     tick(ASYNC_WAIT_PERIOD)
 
     /* Setup for request 2 */
-    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/" + path2)
+    const req2 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + "/api/" + path2)
     expect(req2.request.method).toEqual("GET")
     req2.flush(apiBatchResult)
   }))

--- a/ui/src/app/richskill/service/rich-skill.service.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.ts
@@ -1,6 +1,6 @@
 import { Location } from "@angular/common"
 import { HttpClient, HttpHeaders } from "@angular/common/http"
-import { Injectable } from "@angular/core"
+import { Inject, Injectable } from "@angular/core"
 import { Router } from "@angular/router"
 
 import { Observable, of, throwError } from "rxjs"
@@ -26,8 +26,14 @@ import { ApiTaskResult, ITaskResult } from "../../task/ApiTaskResult"
 
 export class RichSkillService extends AbstractService {
 
-  constructor(httpClient: HttpClient, authService: AuthService, router: Router, location: Location) {
-    super(httpClient, authService, router, location)
+  constructor(
+    httpClient: HttpClient,
+    authService: AuthService,
+    router: Router,
+    location: Location,
+    @Inject("BASE_API") base: string
+  ) {
+    super(httpClient, authService, router, location, base)
   }
 
   private serviceUrl = "api/skills"

--- a/ui/src/app/richskill/service/rich-skill.service.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.ts
@@ -31,9 +31,9 @@ export class RichSkillService extends AbstractService {
     authService: AuthService,
     router: Router,
     location: Location,
-    @Inject("BASE_API") base: string
+    @Inject("BASE_API") baseApi: string
   ) {
-    super(httpClient, authService, router, location, base)
+    super(httpClient, authService, router, location, baseApi)
   }
 
   private serviceUrl = "skills"

--- a/ui/src/app/richskill/service/rich-skill.service.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.ts
@@ -36,7 +36,7 @@ export class RichSkillService extends AbstractService {
     super(httpClient, authService, router, location, base)
   }
 
-  private serviceUrl = "api/skills"
+  private serviceUrl = "skills"
 
   getSkillsFiltered(
     size: number = 50,
@@ -172,7 +172,7 @@ export class RichSkillService extends AbstractService {
     const params = this.buildTableParams(size, from, filterByStatuses, sort)
 
     return this.post<ApiSkillSummary[]>({
-      path: "api/search/skills",
+      path: "search/skills",
       params,
       body: apiSearch,
     })
@@ -187,7 +187,7 @@ export class RichSkillService extends AbstractService {
   libraryExportCsv(): Observable<ApiTaskResult> {
     return this.httpClient
       .get<ApiTaskResult>(
-        this.buildUrl("api/export/library/csv"), {
+        this.buildUrl("export/library/csv"), {
         headers: this.wrapHeaders(new HttpHeaders({
             Accept: "application/json"
           }
@@ -201,7 +201,7 @@ export class RichSkillService extends AbstractService {
   libraryExportXlsx(): Observable<ApiTaskResult> {
     return this.httpClient
       .get<ApiTaskResult>(
-        this.buildUrl("api/export/library/xlsx"), {
+        this.buildUrl("export/library/xlsx"), {
         headers: this.wrapHeaders(new HttpHeaders({
             Accept: "application/json"
           }
@@ -217,7 +217,7 @@ export class RichSkillService extends AbstractService {
     filterByStatuses?: Set<PublishStatus>,
   ): Observable<ApiTaskResult> {
     const params = this.buildTableParams(undefined, undefined, filterByStatuses, undefined)
-    return this.httpClient.post<ApiTaskResult>(this.buildUrl("api/export/skills/csv"), apiSearch, {
+    return this.httpClient.post<ApiTaskResult>(this.buildUrl("export/skills/csv"), apiSearch, {
       params,
       headers: this.wrapHeaders(new HttpHeaders({
           Accept: "application/json"
@@ -235,7 +235,7 @@ export class RichSkillService extends AbstractService {
   ): Observable<ApiTaskResult> {
     const params = this.buildTableParams(undefined, undefined, filterByStatuses, undefined)
     return this.httpClient.post<ApiTaskResult>(
-      this.buildUrl("api/export/skills/xlsx"), apiSearch, {
+      this.buildUrl("export/skills/xlsx"), apiSearch, {
         params,
         headers: this.wrapHeaders(new HttpHeaders({
             Accept: "application/json"
@@ -310,7 +310,7 @@ export class RichSkillService extends AbstractService {
     pollIntervalMs: number = 1000,
   ): Observable<ApiBatchResult> {
     return this.pollForTaskResult(
-      this.bulkStatusChange("api/skills/publish", apiSearch, newStatus, filterByStatuses, collectionUuid),
+      this.bulkStatusChange("skills/publish", apiSearch, newStatus, filterByStatuses, collectionUuid),
       pollIntervalMs
     )
   }
@@ -329,7 +329,7 @@ export class RichSkillService extends AbstractService {
 
   similarityCheck(statement: string): Observable<ApiSkillSummary[]> {
     return this.post<ISkillSummary[]>({
-      path: "api/search/skills/similarity",
+      path: "search/skills/similarity",
       body: {statement}
     })
       .pipe(share())
@@ -340,7 +340,7 @@ export class RichSkillService extends AbstractService {
 
   similaritiesCheck(statements: string[]): Observable<boolean[]> {
     return this.post<boolean[]>({
-      path: "api/search/skills/similarities",
+      path: "search/skills/similarities",
       body: statements.map(statement => ({statement}))
     })
       .pipe(share())

--- a/ui/src/app/search/rich-skill-search-results.component.spec.ts
+++ b/ui/src/app/search/rich-skill-search-results.component.spec.ts
@@ -23,6 +23,7 @@ import { SearchService } from "./search.service"
 import any = jasmine.any
 import {AuthService} from "../auth/auth-service";
 import { of } from "rxjs"
+import { getBaseApi } from "../api-versions"
 
 
 export function createComponent(T: Type<RichSkillSearchResultsComponent>, f?: () => void): Promise<void> {
@@ -75,6 +76,10 @@ describe("RichSkillSearchResultsComponent", () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useValue: routerSpy },
         { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        }
       ]
     })
     .compileComponents()
@@ -271,6 +276,10 @@ describe("RichSkillSearchResultsComponent with latestSearch", () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useValue: routerSpy },
         { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
     .compileComponents()
@@ -321,6 +330,10 @@ describe("RichSkillSearchResultsComponent with params", () => {
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useValue: routerSpy },
         { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
     .compileComponents()
@@ -371,6 +384,10 @@ describe("RichSkillSearchResultsComponent with advance search params in history.
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: Router, useValue: routerSpy },
         { provide: AuthService, useClass: AuthServiceStub },
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ]
     })
       .compileComponents()

--- a/ui/src/app/shared/search-multi-select/search-multi-select.component.spec.ts
+++ b/ui/src/app/shared/search-multi-select/search-multi-select.component.spec.ts
@@ -11,6 +11,7 @@ import {createMockApiNamedReference, createMockJobcode} from "../../../../test/r
 import {of} from "rxjs"
 import {ApiNamedReference, KeywordType} from "../../richskill/ApiSkill"
 import {HttpClientTestingModule} from "@angular/common/http/testing"
+import { getBaseApi } from "../../api-versions"
 
 describe("SearchMultiSelectComponent", () => {
   let component: SearchMultiSelectComponent
@@ -26,6 +27,10 @@ describe("SearchMultiSelectComponent", () => {
         AppConfig,
         KeywordSearchService,
         {provide: AuthService, useClass: AuthServiceStub},
+        {
+          provide: "BASE_API",
+          useFactory: getBaseApi,
+        },
       ],
       imports: [
         HttpClientTestingModule,

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -2,5 +2,7 @@ export const environment = {
   production: true,
   baseApiUrl: "",
   loginUrl: "/oauth2/authorization/okta",
+  apiV2: "",
+  apiV3: "v3",
   dynamicWhitelabel: true
 }

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -2,10 +2,5 @@ export const environment = {
   production: true,
   baseApiUrl: "",
   loginUrl: "/oauth2/authorization/okta",
-  /**
-   * @deprecated
-   */
-  apiV2: "",
-  apiV3: "v3",
   dynamicWhitelabel: true
 }

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -2,6 +2,9 @@ export const environment = {
   production: true,
   baseApiUrl: "",
   loginUrl: "/oauth2/authorization/okta",
+  /**
+   * @deprecated
+   */
   apiV2: "",
   apiV3: "v3",
   dynamicWhitelabel: true

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -5,6 +5,11 @@
 export const environment = {
   production: false,
   baseApiUrl: "http://localhost:8080",
+  /**
+   * @deprecated
+   */
+  apiV2: "",
+  apiV3: "v3",
   loginUrl: "http://localhost:8080/oauth2/authorization/okta",
   dynamicWhitelabel: true
 }

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -5,11 +5,6 @@
 export const environment = {
   production: false,
   baseApiUrl: "http://localhost:8080",
-  /**
-   * @deprecated
-   */
-  apiV2: "",
-  apiV3: "v3",
   loginUrl: "http://localhost:8080/oauth2/authorization/okta",
   dynamicWhitelabel: true
 }


### PR DESCRIPTION
# News

- Add `BASE_API` provider
- Services now receive `BASE_API` by dependency injection
- Default version of the API is v3