### PR TITLE
Build correctly URLs for tasks result

### DIFF
--- a/ui/src/app/abstract.service.spec.ts
+++ b/ui/src/app/abstract.service.spec.ts
@@ -6,8 +6,8 @@ import { async, TestBed } from "@angular/core/testing"
 import { Data, Router } from "@angular/router"
 import { Observable, of } from "rxjs"
 import { map } from "rxjs/operators"
-import { createMockTaskResult } from "../../test/resource/mock-data"
-import { AuthServiceData, AuthServiceStub, RouterData, RouterStub } from "../../test/resource/mock-stubs"
+import { createMockTaskResult } from "@test/resource/mock-data"
+import { AuthServiceData, AuthServiceStub, RouterData, RouterStub } from "@test/resource/mock-stubs"
 import { AbstractService } from "./abstract.service"
 import { AppConfig } from "./app.config"
 import { AuthService } from "./auth/auth-service"
@@ -191,6 +191,12 @@ describe("AbstractService (HTTP needed)", () => {
   it("buildUrl should return", () => {
     const path = "data"
     expect(testService.buildUrl(path)).toEqual(AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path)
+  })
+
+  it("buildUrl should works with tasks", () => {
+    const mockTaskResult = createMockTaskResult()
+    const builtUrl = testService.buildUrl(mockTaskResult.id)
+    expect(builtUrl).toEqual(AppConfig.settings.baseApiUrl + mockTaskResult.id)
   })
 
   /* See https://angular.io/guide/http#testing-http-requests */

--- a/ui/src/app/abstract.service.ts
+++ b/ui/src/app/abstract.service.ts
@@ -106,7 +106,9 @@ export abstract class AbstractService {
     const baseUrl = AppConfig.settings.baseApiUrl
 
     // if user defined, make sure it delineates between the host and path
-    if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
+    if (path.includes("api")) {
+      return baseUrl + path
+    } else if (baseUrl && !baseUrl.endsWith("/") && !path.startsWith("/")) {
       return baseUrl + this.baseApi + "/" + path
     } else {
       return baseUrl + this.baseApi + "/" + path

--- a/ui/src/app/collection/service/collection.service.spec.ts
+++ b/ui/src/app/collection/service/collection.service.spec.ts
@@ -478,7 +478,7 @@ describe("CollectionService", () => {
     const expected = apiBatchResult
     const uuid: string = taskResult.uuid ? taskResult.uuid : ""
     const path1 = getBaseApi() + "/collections/" + uuid + "/updateSkills"
-    const path2 = getBaseApi() + "/" + taskResult.id
+    const path2 = taskResult.id
     const query = "testQueryString"
     const update = new ApiSkillListUpdate({
       add: new ApiSearch({query}),
@@ -522,7 +522,7 @@ describe("CollectionService", () => {
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
     const path1 = getBaseApi() + "/collections/publish"
-    const path2 = getBaseApi() + "/" + taskResult.id
+    const path2 = taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
     const filter = new Set<PublishStatus>([PublishStatus.Draft])

--- a/ui/src/app/richskill/service/rich-skill.service.spec.ts
+++ b/ui/src/app/richskill/service/rich-skill.service.spec.ts
@@ -229,7 +229,7 @@ describe("RichSkillService", () => {
     const skillResult: ApiSkill = new ApiSkill(createMockSkill(now, now, PublishStatus.Published))
     const expected = skillResult
     const path1 = getBaseApi() + "/skills"
-    const path2 = getBaseApi() + "/" + taskResult.id
+    const path2 = taskResult.id
     const skillUpdate = createMockSkillUpdate()
 
     // Act
@@ -353,10 +353,9 @@ describe("RichSkillService", () => {
   it("getResultExportedLibrary", fakeAsync(() => {
     {
       const taskResult = apiTaskResultForCSV
-      const path = "/results/text/" + apiTaskResultForCSV.uuid
-      const path2 = taskResult.id.slice(1)
+      const path2 = taskResult.id
       testService.getResultExportedCsvLibrary(path2).subscribe()
-      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + getBaseApi() + "/" + path2)
+      const req1 = httpTestingController.expectOne(AppConfig.settings.baseApiUrl + path2)
       expect(req1.request.method).toEqual("GET")
       req1.flush("csv")
 
@@ -372,7 +371,7 @@ describe("RichSkillService", () => {
     const apiBatchResult = new ApiBatchResult(createMockBatchResult())
     const expected = apiBatchResult
     const path1 = getBaseApi() + "/skills/publish"
-    const path2 = getBaseApi() + "/" + taskResult.id
+    const path2 = taskResult.id
     const query = "testQueryString"
     const apiSearch = new ApiSearch({ query })
 

--- a/ui/test/resource/mock-data.ts
+++ b/ui/test/resource/mock-data.ts
@@ -220,7 +220,7 @@ export function createMockTaskResult(uuid: string = "uuid1"): ITaskResult {
   return {
     status: PublishStatus.Draft,
     contentType: "my content type",
-    id: "api/tasks/" + uuid,
+    id: "/api/v3/tasks/" + uuid,
     uuid
   }
 }
@@ -295,7 +295,7 @@ export const apiTaskResultForCSV: ApiTaskResult = {
   uuid: "c2624480-4935-4362-bc71-86e052dcb852",
   status: "Processing",
   contentType: "text/csv",
-  id: "/api/results/text/c2624480-4935-4362-bc71-86e052dcb852"
+  id: "/api/v3/results/text/c2624480-4935-4362-bc71-86e052dcb852"
 }
 
 export const apiTaskResultForDeleteCollection: ApiTaskResult = {


### PR DESCRIPTION
Task Result is returning API and version, currently build URL doesn't support that and is building something like this `http://localhost:8080/api//api/v3/results/skills/b4dade07-f162-4af2-b9d2-769018a539f7`

<img width="731" alt="Screenshot 2023-06-13 at 17 31 18" src="https://github.com/wgu-opensource/osmt/assets/68391066/2a62c405-74e5-4fab-8134-bb91d2403f14">


