### PR TITLE
Fix race condition

### DIFF
--- a/ui/src/app/navigation/header.component.spec.ts
+++ b/ui/src/app/navigation/header.component.spec.ts
@@ -77,12 +77,14 @@ describe("HeaderComponent", () => {
     expect(component.canHaveWorkspace).toBeFalse()
   })
 
-  xit("my workspace is visible when user has role admin or curator", (done) => {
+  it("my workspace is visible when user has role admin or curator", (done) => {
     component.canHaveWorkspace = true
+    spyOn(component, "showPublicNavbar").and.returnValue(false)
     fixture.whenStable().then(
       () => {
         fixture.detectChanges()
-
+        console.log(document.getElementsByTagName("body")[0])
+        console.log(component.showPublicNavbar())
         const myWorkspace = fixture.debugElement.query(By.css("#li-my-workspace"))
         expect(myWorkspace).toBeTruthy()
         expect(component.canHaveWorkspace).toBeTrue()

--- a/ui/src/app/navigation/header.component.spec.ts
+++ b/ui/src/app/navigation/header.component.spec.ts
@@ -1,7 +1,6 @@
 import {ComponentFixture, fakeAsync, TestBed, tick} from "@angular/core/testing"
 import {HeaderComponent} from "./header.component"
 import {AuthService} from "../auth/auth-service"
-import {AuthServiceStub} from "../../../test/resource/mock-stubs"
 import {RouterTestingModule} from "@angular/router/testing"
 import {AppConfig} from "../app.config"
 import {EnvironmentService} from "../core/environment.service"
@@ -13,6 +12,8 @@ import {MyWorkspaceComponent} from "../my-workspace/my-workspace.component"
 import {RichSkillsLibraryComponent} from "../richskill/library/rich-skills-library.component"
 import {ButtonAction} from "../auth/auth-roles"
 import {By} from "@angular/platform-browser"
+import { Idle, IdleExpiry } from "@ng-idle/core"
+import { Keepalive } from "@ng-idle/keepalive"
 
 describe("HeaderComponent", () => {
 
@@ -30,7 +31,10 @@ describe("HeaderComponent", () => {
         AppConfig,
         ConcreteService,
         Location,
-        {provide: AuthService, useClass: AuthServiceStub},
+        AuthService,
+        Idle,
+        IdleExpiry,
+        Keepalive
       ],
       imports: [
         HttpClientModule,
@@ -77,14 +81,26 @@ describe("HeaderComponent", () => {
     expect(component.canHaveWorkspace).toBeFalse()
   })
 
+  it("canHaveWorkspace should be false", () => {
+    const authService = TestBed.inject(AuthService)
+    spyOn(authService, "getRole").and.returnValue("ROLE_Osmt_Viewer")
+    component.canHaveWorkspace = component["authService"].isEnabledByRoles(ButtonAction.MyWorkspace)
+    expect(component.canHaveWorkspace).toBeFalse()
+  })
+
+  it("canHaveWorkspace should be true", () => {
+    const authService = TestBed.inject(AuthService)
+    spyOn(authService, "getRole").and.returnValue("ROLE_Osmt_Admin")
+    component.canHaveWorkspace = component["authService"].isEnabledByRoles(ButtonAction.MyWorkspace)
+    expect(component.canHaveWorkspace).toBeTrue()
+  })
+
   it("my workspace is visible when user has role admin or curator", (done) => {
     component.canHaveWorkspace = true
     spyOn(component, "showPublicNavbar").and.returnValue(false)
     fixture.whenStable().then(
       () => {
         fixture.detectChanges()
-        console.log(document.getElementsByTagName("body")[0])
-        console.log(component.showPublicNavbar())
         const myWorkspace = fixture.debugElement.query(By.css("#li-my-workspace"))
         expect(myWorkspace).toBeTruthy()
         expect(component.canHaveWorkspace).toBeTrue()


### PR DESCRIPTION
# When is failing?

After reproduce the error multiple times, I see that it's failing when `showPublicNavbar()` is returning `true`

<img width="1239" alt="Screenshot 2023-06-15 at 10 36 24" src="https://github.com/wgu-opensource/osmt/assets/68391066/84fba92a-9510-4412-9b49-3ef7d18be259">

<br>
<br>

The test finish successfully when `showPublicNavbar()` is returning `false`
<img width="1239" alt="Screenshot 2023-06-15 at 10 37 53" src="https://github.com/wgu-opensource/osmt/assets/68391066/59334ff2-f345-47d6-bc0d-8e25ccbedad3">


# Why?

`*ngIf` for workspace is inside other `*ngIf` that uses `showPublicNavbar()`  so if ul doesn't exist li doesn't exist either.

<img width="1131" alt="Screenshot 2023-06-15 at 10 52 48" src="https://github.com/wgu-opensource/osmt/assets/68391066/b9dabaf8-b5ac-4875-bb08-07d4ff4bfe34">


# Solution
Spy on `showPublicNavbar()` to return `false`.

