### PR TITLE
added osmt-api exclusions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -475,17 +475,22 @@
                                 <exclude>AuditLogRepositoryTest</exclude>
                                 <exclude>BatchImportRichSkillTest</exclude>
                                 <exclude>BlsImportTest</exclude>
+                                <exclude>CollectionControllerTest</exclude>
                                 <exclude>CollectionEsRepoTest</exclude>
                                 <exclude>CollectionRepositoryTest</exclude>
+                                <exclude>CollectionUpdateObjectTest</exclude>
                                 <exclude>ElasticSearchReindexerTest</exclude>
                                 <exclude>JobCodeEsRepoTest</exclude>
                                 <exclude>JobCodeRepositoryTest</exclude>
+                                <exclude>KeywordControllerTest</exclude>
                                 <exclude>KeywordEsRepoTest</exclude>
                                 <exclude>KeywordRepositoryTest</exclude>
                                 <exclude>OnetImportTest</exclude>
                                 <exclude>RichSkillControllerTest</exclude>
                                 <exclude>RichSkillEsRepoTest</exclude>
                                 <exclude>RichSkillRepositoryTest</exclude>
+                                <exclude>RichSkillSortOrderTest</exclude>
+                                <exclude>RichSkillXlsxExportTest</exclude>
                                 <exclude>SearchControllerTest</exclude>
                                 <exclude>TaskTest</exclude>
                             </excludes>


### PR DESCRIPTION
Some exclusions added to osmt-api pom file.

We have some test classes in osmt-api that use docker test containers and we do not want that to interfere with our docker build as they do not have access to other docker containers. So we exclude them from the docker build profile that we are using which is "dockerfile-build"

Used the following command to execute docker build in local:
docker build --build-arg RELEASE_TAG="0.0" --build-arg MVN_POM_VERSION="2.6.0-SNAPSHOT" -t "wguopensource/osmt-app:0.0" -t wguopensource/osmt-app:latest --progress plain .

Note: Do not miss the . at the end
 