### PR TITLE
Feature/utf8mb4

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,7 +36,8 @@
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.coroutines.version>1.5.1</kotlin.coroutines.version>
         <exposed.version>0.24.1</exposed.version>
-        <flywaydb.version>7.15.0</flywaydb.version>
+        <flywaydb.version>8.5.13</flywaydb.version>
+        <flyway-mysql>8.5.13</flyway-mysql>
         <okta.version>2.1.5</okta.version>
 <!--        TODO - is this needed?-->
         <kotest.version>4.1.3</kotest.version>
@@ -231,6 +232,12 @@
             <artifactId>flyway-core</artifactId>
             <version>${flywaydb.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <version>${flyway-mysql}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/api/src/main/resources/db/migration/V2023.07.05__alter_schema.sql
+++ b/api/src/main/resources/db/migration/V2023.07.05__alter_schema.sql
@@ -1,0 +1,73 @@
+USE osmt_db;
+
+ALTER SCHEMA osmt_db
+DEFAULT CHARACTER SET = utf8mb4;
+
+ALTER SCHEMA osmt_db
+DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+-- AuditLog: table
+ALTER TABLE `AuditLog`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `user` varchar(256) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `operationType` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `tableName` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `changedFields` text COLLATE utf8mb4_unicode_ci NOT NULL;
+
+-- Collection: table
+ALTER TABLE `Collection`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `uuid` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `workspace_owner` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+    MODIFY `status` enum('unarchived','deleted','workspace','published','archived','draft') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'draft',
+    MODIFY `description` text COLLATE utf8mb4_unicode_ci;
+
+-- CollectionSkills: table
+ALTER TABLE `CollectionSkills`
+    DEFAULT CHARSET=utf8mb4,
+    DEFAULT COLLATE = utf8mb4_unicode_ci;
+
+-- JobCode: table
+ALTER TABLE `JobCode`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `code` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `name` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `major` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `minor` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `broad` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `detailed` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `description` text COLLATE utf8mb4_unicode_ci,
+    MODIFY `framework` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `url` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
+
+-- Keyword: table
+ALTER TABLE `Keyword`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `keyword_type_enum` enum('Category','Keyword','Standard','Certification','Alignment','Employer','Author') COLLATE utf8mb4_unicode_ci NOT NULL;
+
+-- RichSkillDescriptor: table
+ALTER TABLE `RichSkillDescriptor`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `uuid` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `statement` text COLLATE utf8mb4_unicode_ci NOT NULL;
+
+-- RichSkillJobCodes: table
+ALTER TABLE `RichSkillJobCodes`
+    DEFAULT CHARSET=utf8mb4,
+    DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+-- RichSkillKeywords: table
+ALTER TABLE `RichSkillKeywords`
+    DEFAULT CHARSET=utf8mb4,
+    DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+-- flyway_schema_history: table
+ALTER TABLE `flyway_schema_history`
+    DEFAULT CHARSET=utf8mb4,
+    MODIFY `version` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `description` varchar(200) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `type` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `script` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `installed_by` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL;

--- a/api/src/main/resources/db/migration/V2023.07.05__alter_schema.sql
+++ b/api/src/main/resources/db/migration/V2023.07.05__alter_schema.sql
@@ -44,7 +44,10 @@ ALTER TABLE `JobCode`
 -- Keyword: table
 ALTER TABLE `Keyword`
     DEFAULT CHARSET=utf8mb4,
-    MODIFY `keyword_type_enum` enum('Category','Keyword','Standard','Certification','Alignment','Employer','Author') COLLATE utf8mb4_unicode_ci NOT NULL;
+    MODIFY `value` varchar(767) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `uri` varchar(767) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+    MODIFY `keyword_type_enum` enum('Category','Keyword','Standard','Certification','Alignment','Employer','Author') COLLATE utf8mb4_unicode_ci NOT NULL,
+    MODIFY `framework` varchar(767) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
 
 -- RichSkillDescriptor: table
 ALTER TABLE `RichSkillDescriptor`

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -33,7 +33,7 @@ services:
 
   db:
     image: library/mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb3 --collation-server=utf8mb3_unicode_ci
+    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - sql_db:/var/lib/mysql:rw
       - ./docker/mysql-init:/docker-entrypoint-initdb.d

--- a/docker/dev-stack.yml
+++ b/docker/dev-stack.yml
@@ -4,7 +4,7 @@ version: '3.3'
 services:
   db:
     image: library/mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb3 --collation-server=utf8mb3_unicode_ci
+    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - sql_db:/var/lib/mysql:rw
       - ./mysql-init:/docker-entrypoint-initdb.d


### PR DESCRIPTION
This is PR for converting existing my sql schema from using utf8mb3 to utf8mb4.

The following documents have been used as a reference along with official mysql documentation in this migration.
https://www.percona.com/blog/migrating-to-utf8mb4-things-to-consider/
https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-conversion.html

Hence the varchar columns have been adjusted to suit 4 byte unicode characters.