### PR TITLE
Update GH Workflow to use latest ubuntu image

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   api-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout out branch

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Change runner back to `ubuntu-latest` which is the preferred image state. Was previously set to an earlier ubuntu version on PR #374 to address runner errors causing build failure within the GitHub environment.